### PR TITLE
fix: yarn dls -> dlx

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -25,7 +25,7 @@ export const AGENTS = {
     'add': 'yarn add {0}',
     'upgrade': 'yarn upgrade {0}',
     'upgrade-interactive': 'yarn upgrade-interactive',
-    'execute': 'yarn dls {0}',
+    'execute': 'yarn dlx {0}',
     'uninstall': 'yarn remove {0}',
     'global_uninstall': 'yarn global remove {0}',
   },


### PR DESCRIPTION
`dlx` command is only available for yarn [`v2.1.0` and above](https://github.com/yarnpkg/berry/blob/master/CHANGELOG.md#new-commands), and people have to enable it via [`yarn set version berry`](https://yarnpkg.com/getting-started/install#per-project-install)