### PR TITLE
refactor: replace `execa` with `ezspawn`

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@antfu/eslint-config": "^2.1.1",
+    "@jsdevtools/ez-spawn": "^3.0.4",
     "@posva/prompts": "^2.4.4",
     "@types/fs-extra": "^11.0.4",
     "@types/ini": "^1.3.33",
@@ -57,7 +58,6 @@
     "bumpp": "^9.2.0",
     "eslint": "^8.54.0",
     "esno": "^4.0.0",
-    "execa": "^8.0.1",
     "fast-glob": "^3.3.2",
     "find-up": "^6.3.0",
     "fs-extra": "^11.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ devDependencies:
   '@antfu/eslint-config':
     specifier: ^2.1.1
     version: 2.1.1(eslint@8.54.0)(typescript@5.3.2)(vitest@0.34.6)
+  '@jsdevtools/ez-spawn':
+    specifier: ^3.0.4
+    version: 3.0.4
   '@posva/prompts':
     specifier: ^2.4.4
     version: 2.4.4
@@ -32,9 +35,6 @@ devDependencies:
   esno:
     specifier: ^4.0.0
     version: 4.0.0
-  execa:
-    specifier: ^8.0.1
-    version: 8.0.1
   fast-glob:
     specifier: ^3.3.2
     version: 3.3.2

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
-import { execaCommand } from 'execa'
+import { async as ezspawn } from '@jsdevtools/ez-spawn'
 import { findUp } from 'find-up'
 import terminalLink from 'terminal-link'
 import prompts from '@posva/prompts'
@@ -75,7 +75,7 @@ export async function detect({ autoInstall, programmatic, cwd }: DetectOptions =
         process.exit(1)
     }
 
-    await execaCommand(`npm i -g ${agent.split('@')[0]}${version ? `@${version}` : ''}`, { stdio: 'inherit', cwd })
+    await ezspawn(`npm i -g ${agent.split('@')[0]}${version ? `@${version}` : ''}`, { stdio: 'inherit', cwd })
   }
 
   return agent

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -2,8 +2,8 @@
 import { resolve } from 'node:path'
 import process from 'node:process'
 import prompts from '@posva/prompts'
-import type { Options as ExecaOptions } from 'execa'
-import { execaCommand } from 'execa'
+import type { Options as EzSpawnOptions } from '@jsdevtools/ez-spawn'
+import { async as ezspawn } from '@jsdevtools/ez-spawn'
 import c from 'kleur'
 import { version } from '../package.json'
 import type { Agent } from './agents'
@@ -86,7 +86,7 @@ export async function run(fn: Runner, args: string[], options: DetectOptions = {
 
   if (args.length === 1 && (args[0]?.toLowerCase() === '-v' || args[0] === '--version')) {
     const getCmd = (a: Agent) => agents.includes(a) ? getCommand(a, 'agent', ['-v']) : `${a} -v`
-    const getV = (a: string, o?: ExecaOptions) => execaCommand(getCmd(a as Agent), o).then(e => e.stdout).then(e => e.startsWith('v') ? e : `v${e}`)
+    const getV = (a: string, o: EzSpawnOptions = {}) => ezspawn(getCmd(a as Agent), o).then(e => e.stdout).then(e => e.startsWith('v') ? e : `v${e}`)
     const globalAgentPromise = getGlobalAgent()
     const globalAgentVersionPromise = globalAgentPromise.then(getV)
     const agentPromise = detect({ ...options, cwd }).then(a => a || '')
@@ -139,5 +139,5 @@ export async function run(fn: Runner, args: string[], options: DetectOptions = {
     return
   }
 
-  await execaCommand(command, { stdio: 'inherit', cwd })
+  await ezspawn(command, { stdio: 'inherit', cwd })
 }

--- a/test/programmatic/runCli.spec.ts
+++ b/test/programmatic/runCli.spec.ts
@@ -26,7 +26,7 @@ function runCliTest(fixtureName: string, agent: string, runner: Runner, args: st
         args,
       },
     ).catch((e) => {
-      // it will always throw if execa is mocked
+      // it will always throw if ezspawn is mocked
       if (e.command)
         expect(e.command).toMatchSnapshot()
       else
@@ -41,11 +41,11 @@ beforeAll(() => {
   errorLog = vi.spyOn(console, 'error')
   infoLog = vi.spyOn(console, 'info')
 
-  vi.mock('execa', async (importOriginal) => {
+  vi.mock('@jsdevtools/ez-spawn', async (importOriginal) => {
     const mod = await importOriginal() as any
     return {
       ...mod,
-      execaCommand: (cmd: string) => {
+      async: (cmd: string) => {
         // break execution flow for easier snapshotting
         // eslint-disable-next-line no-throw-literal
         throw { command: cmd }


### PR DESCRIPTION
### Description

Replace `execa` w/ `ezspawn`, see also https://github.com/antfu-collective/taze/pull/115

### Linked Issues

N/A

### Additional context

The PR reduces the final dist size by 36 KiB:

**Previous**

![image](https://github.com/antfu-collective/ni/assets/40715044/676649f3-b3c3-44f8-a5e2-2dfe6af7bb0b)

**After**

![image](https://github.com/antfu-collective/ni/assets/40715044/d3fd7a8c-75cb-437b-8f5b-dff4b5258a22)

