### PR TITLE
fix(bun): incorrect bun frozen-lockfile command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ ni --frozen
 # yarn install --frozen-lockfile (Yarn 1)
 # yarn install --immutable (Yarn Berry)
 # pnpm install --frozen-lockfile
-# bun install --no-save
+# bun install --frozen-lockfile
 ```
 
 ```bash
@@ -160,7 +160,7 @@ nci
 # npm ci
 # yarn install --frozen-lockfile
 # pnpm install --frozen-lockfile
-# bun install --no-save
+# bun install --frozen-lockfile
 ```
 
 if the corresponding node manager is not present, this command will install it globally along the way.

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -36,7 +36,7 @@ const bun = {
   'agent': 'bun {0}',
   'run': 'bun run {0}',
   'install': 'bun install {0}',
-  'frozen': 'bun install --no-save',
+  'frozen': 'bun install --frozen-lockfile',
   'global': 'bun add -g {0}',
   'add': 'bun add {0}',
   'upgrade': 'bun update {0}',

--- a/test/ni/bun.spec.ts
+++ b/test/ni/bun.spec.ts
@@ -22,4 +22,4 @@ it('multiple', _('eslint @types/node', 'bun add eslint @types/node'))
 
 it('global', _('eslint -g', 'bun add -g eslint'))
 
-it('frozen', _('--frozen', 'bun install --no-save'))
+it('frozen', _('--frozen', 'bun install --frozen-lockfile'))

--- a/test/programmatic/__snapshots__/runCli.spec.ts.snap
+++ b/test/programmatic/__snapshots__/runCli.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`lockfile > bun > na 1`] = `"bun"`;
 
 exports[`lockfile > bun > na run foo 1`] = `"bun run foo"`;
 
-exports[`lockfile > bun > ni --frozen 1`] = `"bun install --no-save"`;
+exports[`lockfile > bun > ni --frozen 1`] = `"bun install --frozen-lockfile"`;
 
 exports[`lockfile > bun > ni -g foo 1`] = `"npm i -g foo"`;
 
@@ -172,7 +172,7 @@ exports[`packager > bun > na 1`] = `"bun"`;
 
 exports[`packager > bun > na run foo 1`] = `"bun run foo"`;
 
-exports[`packager > bun > ni --frozen 1`] = `"bun install --no-save"`;
+exports[`packager > bun > ni --frozen 1`] = `"bun install --frozen-lockfile"`;
 
 exports[`packager > bun > ni -g foo 1`] = `"npm i -g foo"`;
 


### PR DESCRIPTION
### Description

Fixed incorrect commands related to the `bun` frozen-lockfile option.

The original implementation incorrectly used `bun install --no-save` for the frozen-lockfile option. The correct command should be `bun install --frozen-lockfile`, as per the `bun` documentation.

### Linked Issues

<!-- If applicable, reference the issue this PR solves, e.g. `fixes #123`. -->

### Additional context

The `bun` documentation under the bun install section [here](https://bun.sh/docs/cli/install#production-mode) states:

> For reproducible installs, use `--frozen-lockfile`. This will install the exact versions of each package specified in the lockfile. If your `package.json` disagrees with `bun.lockb`, Bun will exit with an error. The lockfile will not be updated.

> $ bun install --frozen-lockfile


Additionally, the lockfile section [here](https://bun.sh/docs/install/lockfile) mentions:

> Can I opt out?
> To install without creating a lockfile:

> bun install --no-save

The previous implementation incorrectly used `--no-save` in the frozen-lockfile 