### PR TITLE
fix: missing CLI help text

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -121,6 +121,7 @@ export async function run(fn: Runner, args: string[], options: DetectOptions = {
     console.log(`nci   ${dash}  clean install`)
     console.log(`na    ${dash}  agent alias`)
     console.log(`ni -v ${dash}  show used agent`)
+    console.log(`ni -i ${dash}  interactive package management`)
     console.log(c.yellow('\ncheck https://github.com/antfu/ni for more documentation.'))
     return
   }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Help text is missing from the CLI message.

```
ni -h
@antfu/ni use the right package manager v0.22.0

ni    -  install
nr    -  run
nlx   -  execute
nu    -  upgrade
nun   -  uninstall
nci   -  clean install
na    -  agent alias
ni -v -  show used agent
```

### Linked Issues

No issue but [PR #202] exists.

<!-- ### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
