### PR TITLE
fix: `bun x` instead of `bunx`

### DIFF
--- a/src/agents.ts
+++ b/src/agents.ts
@@ -41,7 +41,7 @@ const bun = {
   'add': 'bun add {0}',
   'upgrade': 'bun update {0}',
   'upgrade-interactive': 'bun update {0}',
-  'execute': 'bunx {0}',
+  'execute': 'bun x {0}',
   'uninstall': 'bun remove {0}',
   'global_uninstall': 'bun remove -g {0}',
 }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Even though the Bun documentation says that the command `bunx` is just an alias of `bun x`, in reality `bunx` often doesn't work when `bun x` does. I suggest using `bun x` every time.

### Linked Issues

No issue was created

### Additional context

To demonstrate the difference between `bunx` and `bun x`, just try to init a Nuxt project with each. `bunx` fails while `bun x` successfully runs.

This may not be the case with all operating systems and/or all Bun installation methods. I'm using WIndows 11 and Bun was installed via npm.