### PR TITLE
chore(runner): delete useless if-statement used to print version info

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -122,11 +122,6 @@ export async function run(fn: Runner, args: string[], options: DetectOptions = {
     return
   }
 
-  if (args.length === 1 && (args[0] === '--version' || args[0] === '-v')) {
-    console.log(`@antfu/ni v${version}`)
-    return
-  }
-
   if (args.length === 1 && ['-h', '--help'].includes(args[0])) {
     const dash = c.dim('-')
     console.log(c.green(c.bold('@antfu/ni')) + c.dim(` use the right package manager v${version}\n`))


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

The if-statement used to print version info seems duplicated from the previous one, making it unnecessary.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
