### PR TITLE
fix: nr command lastRunCommand not work

### DIFF
--- a/src/commands/nr.ts
+++ b/src/commands/nr.ts
@@ -69,6 +69,8 @@ runCli(async (agent, args, ctx) => {
         type: 'autocomplete',
         choices,
         async suggest(input: string, choices: Choice[]) {
+          if (!input)
+            return choices
           const results = fzf.find(input)
           return results.map(r => choices.find(c => c.value === r.item.key))
         },


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
First of all, I would like to express my gratitude for developing ni, which I really enjoy using. During my usage, I wished for a feature to repeat the last command, and after reviewing the code, I discovered that this feature already exists, but it does not function on several of my devices.

Eventually, I found that the `suggest` section of the code executes once upon initial display, at which time the input is empty, leading to a display order that is inconsistent with expectations.


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
