### PR TITLE
chore: bump ` package-manager-detector` to `v0.2.8`

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "fzf": "^0.5.2",
     "ini": "^5.0.0",
     "lint-staged": "^15.2.10",
-    "package-manager-detector": "^0.2.4",
+    "package-manager-detector": "^0.2.8",
     "picocolors": "^1.1.1",
     "simple-git-hooks": "^2.11.1",
     "taze": "^0.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^15.2.10
         version: 15.2.10
       package-manager-detector:
-        specifier: ^0.2.4
-        version: 0.2.4
+        specifier: ^0.2.8
+        version: 0.2.8
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -2542,8 +2542,8 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
-  package-manager-detector@0.2.4:
-    resolution: {integrity: sha512-H/OUu9/zUfP89z1APcBf2X8Us0tt8dUK4lUmKqz12QNXif3DxAs1/YqjGtcutZi1zQqeNQRWr9C+EbQnnvSSFA==}
+  package-manager-detector@0.2.8:
+    resolution: {integrity: sha512-ts9KSdroZisdvKMWVAVCXiKqnqNfXz4+IbrBG8/BWx/TR5le+jfenvoBuIZ6UWM9nz47W7AbD9qYfAwfWMIwzA==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -3205,7 +3205,7 @@ snapshots:
 
   '@antfu/install-pkg@0.4.1':
     dependencies:
-      package-manager-detector: 0.2.4
+      package-manager-detector: 0.2.8
       tinyexec: 0.3.1
 
   '@antfu/ni@0.23.0': {}
@@ -4095,7 +4095,7 @@ snapshots:
       '@vue/compiler-ssr': 3.4.31
       '@vue/shared': 3.4.31
       estree-walker: 2.0.2
-      magic-string: 0.30.10
+      magic-string: 0.30.13
       postcss: 8.4.39
       source-map-js: 1.2.0
 
@@ -5673,7 +5673,7 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  package-manager-detector@0.2.4: {}
+  package-manager-detector@0.2.8: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -5992,7 +5992,7 @@ snapshots:
       '@antfu/ni': 0.23.0
       js-yaml: 4.1.0
       ofetch: 1.4.1
-      package-manager-detector: 0.2.4
+      package-manager-detector: 0.2.8
       tinyexec: 0.3.1
       unconfig: 0.6.0
       yargs: 17.7.2


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Updated the version of `package-manager-detector` so that `ni` works in Bun projects with the new `text-lockfile`.

Mainly for this PR: https://github.com/antfu-collective/package-manager-detector/pull/38

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
