### PR TITLE
feat: add support for production install

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ ni @types/node -D
 ```
 
 ```bash
+ni -P
+
+# npm i --omit=dev
+# yarn install --production
+# pnpm i --production
+# bun install --production
+```
+
+```bash
 ni --frozen
 
 # npm ci

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -27,6 +27,13 @@ export const parseNi = <Runner>((agent, args, ctx) => {
   if (agent === 'bun')
     args = args.map(i => i === '-D' ? '-d' : i)
 
+  // npm use `--omit=dev` instead of `--production`
+  if (agent === 'npm')
+    args = args.map(i => i === '-P' ? '--omit=dev' : i)
+
+  if (args.includes('-P'))
+    args = args.map(i => i === '-P' ? '--production' : i)
+
   if (args.includes('-g'))
     return getCommand(agent, 'global', exclude(args, '-g'))
 

--- a/test/ni/bun.spec.ts
+++ b/test/ni/bun.spec.ts
@@ -23,3 +23,5 @@ it('multiple', _('eslint @types/node', 'bun add eslint @types/node'))
 it('global', _('eslint -g', 'bun add -g eslint'))
 
 it('frozen', _('--frozen', 'bun install --frozen-lockfile'))
+
+it('production', _('-P', 'bun install --production'))

--- a/test/ni/npm.spec.ts
+++ b/test/ni/npm.spec.ts
@@ -23,3 +23,5 @@ it('-D', _('eslint @types/node -D', 'npm i eslint @types/node -D'))
 it('global', _('eslint -g', 'npm i -g eslint'))
 
 it('frozen', _('--frozen', 'npm ci'))
+
+it('production', _('-P', 'npm i --omit=dev'))

--- a/test/ni/pnpm.spec.ts
+++ b/test/ni/pnpm.spec.ts
@@ -26,3 +26,5 @@ it('frozen', _('--frozen', 'pnpm i --frozen-lockfile'))
 
 it('forward1', _('--anything', 'pnpm i --anything'))
 it('forward2', _('-a', 'pnpm i -a'))
+
+it('production', _('-P', 'pnpm i --production'))

--- a/test/ni/yarn.spec.ts
+++ b/test/ni/yarn.spec.ts
@@ -23,3 +23,5 @@ it('-D', _('eslint @types/node -D', 'yarn add eslint @types/node -D'))
 it('global', _('eslint ni -g', 'yarn global add eslint ni'))
 
 it('frozen', _('--frozen', 'yarn install --frozen-lockfile'))
+
+it('production', _('-P', 'yarn install --production'))

--- a/test/ni/yarn@berry.spec.ts
+++ b/test/ni/yarn@berry.spec.ts
@@ -23,3 +23,5 @@ it('-D', _('eslint @types/node -D', 'yarn add eslint @types/node -D'))
 it('global', _('eslint ni -g', 'npm i -g eslint ni'))
 
 it('frozen', _('--frozen', 'yarn install --immutable'))
+
+it('production', _('-P', 'yarn install --production'))


### PR DESCRIPTION
### Description

Add support for installing only production dependencies by passing `-P` flag.
```
ni -P
```
This allows for installing only the production dependencies to allow more lightweight runtimes. See #250 for more details.

### Linked Issues
fixes #250


### Additional context
Not sure how much value the comment
```ts
// npm use `--omit=dev` instead of `--production`
```
is adding, but I included it for symmetry with the previous comment above.
