### PR TITLE
feat: support frozen production install

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ ni --frozen
 ```
 
 ```bash
+ni --frozen -P
+
+# npm ci --omit=dev
+# yarn install --frozen-lockfile --production (Yarn 1)
+# yarn install --immutable --production (Yarn Berry)
+# pnpm install --frozen-lockfile --production
+# bun install --frozen-lockfile --production
+```
+
+```bash
 ni -g eslint
 
 # npm i -g eslint
@@ -195,6 +205,16 @@ nci
 # yarn install --frozen-lockfile
 # pnpm install --frozen-lockfile
 # bun install --frozen-lockfile
+```
+
+```bash
+nci -P
+
+# npm ci --omit=dev
+# yarn install --frozen-lockfile --production (Yarn 1)
+# yarn install --immutable --production (Yarn Berry)
+# pnpm install --frozen-lockfile --production
+# bun install --frozen-lockfile --production
 ```
 
 if the corresponding node manager is not present, this command will install it globally along the way.

--- a/README.md
+++ b/README.md
@@ -63,16 +63,6 @@ ni --frozen
 ```
 
 ```bash
-ni --frozen -P
-
-# npm ci --omit=dev
-# yarn install --frozen-lockfile --production (Yarn 1)
-# yarn install --immutable --production (Yarn Berry)
-# pnpm install --frozen-lockfile --production
-# bun install --frozen-lockfile --production
-```
-
-```bash
 ni -g eslint
 
 # npm i -g eslint
@@ -205,16 +195,6 @@ nci
 # yarn install --frozen-lockfile
 # pnpm install --frozen-lockfile
 # bun install --frozen-lockfile
-```
-
-```bash
-nci -P
-
-# npm ci --omit=dev
-# yarn install --frozen-lockfile --production (Yarn 1)
-# yarn install --immutable --production (Yarn Berry)
-# pnpm install --frozen-lockfile --production
-# bun install --frozen-lockfile --production
 ```
 
 if the corresponding node manager is not present, this command will install it globally along the way.

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "fzf": "^0.5.2",
     "ini": "^5.0.0",
     "lint-staged": "^15.4.2",
-    "package-manager-detector": "^0.2.8",
+    "package-manager-detector": "^0.2.9",
     "picocolors": "^1.1.1",
     "simple-git-hooks": "^2.11.1",
     "taze": "^18.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
         version: 15.4.2
       package-manager-detector:
         specifier: ^0.2.8
-        version: 0.2.8
+        version: link:../package-manager-detector
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^15.4.2
         version: 15.4.2
       package-manager-detector:
-        specifier: ^0.2.8
-        version: 0.2.8
+        specifier: ^0.2.9
+        version: 0.2.9
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -2315,8 +2315,8 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
-  package-manager-detector@0.2.8:
-    resolution: {integrity: sha512-ts9KSdroZisdvKMWVAVCXiKqnqNfXz4+IbrBG8/BWx/TR5le+jfenvoBuIZ6UWM9nz47W7AbD9qYfAwfWMIwzA==}
+  package-manager-detector@0.2.9:
+    resolution: {integrity: sha512-+vYvA/Y31l8Zk8dwxHhL3JfTuHPm6tlxM2A3GeQyl7ovYnSp1+mzAxClxaOr0qO1TtPxbQxetI7v5XqKLJZk7Q==}
 
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -3132,7 +3132,7 @@ snapshots:
 
   '@antfu/install-pkg@1.0.0':
     dependencies:
-      package-manager-detector: 0.2.8
+      package-manager-detector: 0.2.9
       tinyexec: 0.3.2
 
   '@antfu/ni@23.2.0': {}
@@ -4029,7 +4029,7 @@ snapshots:
       escalade: 3.2.0
       js-yaml: 4.1.0
       jsonc-parser: 3.3.1
-      package-manager-detector: 0.2.8
+      package-manager-detector: 0.2.9
       prompts: 2.4.2
       semver: 7.6.3
       tinyexec: 0.3.2
@@ -5456,7 +5456,7 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  package-manager-detector@0.2.8: {}
+  package-manager-detector@0.2.9: {}
 
   parent-module@1.0.1:
     dependencies:
@@ -5935,7 +5935,7 @@ snapshots:
       '@antfu/ni': 23.2.0
       js-yaml: 4.1.0
       ofetch: 1.4.1
-      package-manager-detector: 0.2.8
+      package-manager-detector: 0.2.9
       tinyexec: 0.3.2
       unconfig: 0.6.1
       yargs: 17.7.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
         version: 15.4.2
       package-manager-detector:
         specifier: ^0.2.8
-        version: link:../package-manager-detector
+        version: 0.2.8
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1

--- a/src/commands/nci.ts
+++ b/src/commands/nci.ts
@@ -2,6 +2,6 @@ import { parseNi } from '../parse'
 import { runCli } from '../runner'
 
 runCli(
-  (agent, _, hasLock) => parseNi(agent, ['--frozen-if-present'], hasLock),
+  (agent, args, hasLock) => parseNi(agent, [...args, '--frozen-if-present'], hasLock),
   { autoInstall: true },
 )

--- a/test/ni/bun.spec.ts
+++ b/test/ni/bun.spec.ts
@@ -25,3 +25,5 @@ it('global', _('eslint -g', 'bun add -g eslint'))
 it('frozen', _('--frozen', 'bun install --frozen-lockfile'))
 
 it('production', _('-P', 'bun install --production'))
+
+it('frozen production', _('--frozen -P', 'bun install --frozen-lockfile --production'))

--- a/test/ni/npm.spec.ts
+++ b/test/ni/npm.spec.ts
@@ -25,3 +25,5 @@ it('global', _('eslint -g', 'npm i -g eslint'))
 it('frozen', _('--frozen', 'npm ci'))
 
 it('production', _('-P', 'npm i --omit=dev'))
+
+it('frozen production', _('--frozen -P', 'npm ci --omit=dev'))

--- a/test/ni/pnpm.spec.ts
+++ b/test/ni/pnpm.spec.ts
@@ -28,3 +28,5 @@ it('forward1', _('--anything', 'pnpm i --anything'))
 it('forward2', _('-a', 'pnpm i -a'))
 
 it('production', _('-P', 'pnpm i --production'))
+
+it('frozen production', _('--frozen -P', 'pnpm i --frozen-lockfile --production'))

--- a/test/ni/yarn.spec.ts
+++ b/test/ni/yarn.spec.ts
@@ -25,3 +25,5 @@ it('global', _('eslint ni -g', 'yarn global add eslint ni'))
 it('frozen', _('--frozen', 'yarn install --frozen-lockfile'))
 
 it('production', _('-P', 'yarn install --production'))
+
+it('frozen production', _('--frozen -P', 'yarn install --frozen-lockfile --production'))

--- a/test/ni/yarn@berry.spec.ts
+++ b/test/ni/yarn@berry.spec.ts
@@ -25,3 +25,5 @@ it('global', _('eslint ni -g', 'npm i -g eslint ni'))
 it('frozen', _('--frozen', 'yarn install --immutable'))
 
 it('production', _('-P', 'yarn install --production'))
+
+it('frozen production', _('--frozen -P', 'yarn install --immutable --production'))


### PR DESCRIPTION
### Description

Adds support for installing only production dependencies while adhering to lock file specification and ensuring it is consistent with package.json

Allows user to call `nci -P` or `ni --frozen -P` to do so.

> [!WARNING]  
> `pnpm-lock.yaml` points to a linked version of `package-manager-detector`, which I used locally to develop. https://github.com/antfu-collective/package-manager-detector/pull/40 should be merged and released first, and the version of the new release should be used as a dependency before merging and releasing changes from this PR.

### Linked Issues
#254 and to extent #250 (as the seed of the idea)

### Additional context

resolves #254 

Builds are failing due to the usage of linking mentioned in the warning section above - `nr build` runs OK locally with `package-manager-detector` linked to https://github.com/antfu-collective/package-manager-detector/pull/40.
