### PR TITLE
docs: add info about `bun.lock`

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ asdf global ni latest
 
 **ni** assumes that you work with lockfiles (and you should)
 
-Before it runs, it will detect your `yarn.lock` / `pnpm-lock.yaml` / `package-lock.json` / `bun.lockb` to know current package manager (or `packageManager` field in your packages.json if specified), and runs the [corresponding commands](https://github.com/antfu/ni/blob/main/src/agents.ts).
+Before it runs, it will detect your `yarn.lock` / `pnpm-lock.yaml` / `package-lock.json` / `bun.lock` / `bun.lockb` to know current package manager (or `packageManager` field in your packages.json if specified), and runs the [corresponding commands](https://github.com/antfu/ni/blob/main/src/agents.ts).
 
 ### Trouble shooting
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

`ni` already supports bun's new text-based lockfile format (`bun.lock` instead of `bun.lockb`) since upgrading package-manager-detector to [v0.2.8](https://github.com/antfu-collective/package-manager-detector/releases/tag/v0.2.8). this PR only adds this info into the readme.

### Linked Issues

#249 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
