### PR TITLE
fix: correct array expansion in completion script

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,6 @@ nr -
 # rerun the last command
 ```
 
-```bash
-nr --completion >> ~/.bashrc
-
-# add completion script to your shell (only bash supported for now)
-```
-
 <br>
 
 ### `nlx` - download & execute
@@ -291,6 +285,34 @@ asdf install ni latest
 asdf global ni latest
 ```
 
+#### shell
+
+You can use `nr` with completion in bash and zsh shells
+
+##### bash
+> [!Note]
+> Bash completions require [bash-completions](https://github.com/scop/bash-completion) to be installed and configured
+
+```bash
+nr --print-completions bash >> ~/.bashrc
+
+```
+
+##### zsh
+If you have [oh-my-zsh](https://ohmyz.sh/) installed
+```zsh
+nr --print-completions zsh >> ~/.oh-my-zsh/completions/_nr
+```
+
+Without oh-my-zsh
+```
+mkdir -p ~/.zsh/completions
+nr --print-completions zsh >> ~/.zsh/completions/_nr
+
+fpath=(~/.zsh/completion $fpath)
+autoload -U compinit
+compinit
+```
 ### How?
 
 **ni** assumes that you work with lock-files (and you should).

--- a/src/commands/nr.ts
+++ b/src/commands/nr.ts
@@ -3,7 +3,7 @@ import type { RunnerContext } from '../runner'
 import process from 'node:process'
 import prompts from '@posva/prompts'
 import { byLengthAsc, Fzf } from 'fzf'
-import { rawCompletionScript } from '../completion'
+import { printCompletionScript } from '../completion'
 import { getPackageJSON } from '../fs'
 import { parseNr } from '../parse'
 import { runCli } from '../runner'
@@ -53,9 +53,14 @@ runCli(async (agent, args, ctx) => {
       }
     }
     else {
-      // eslint-disable-next-line no-console
-      console.log(rawCompletionScript)
+      // Print `bash` completions if no argument is provided, for backwards compatibility
+      printCompletionScript('bash')
     }
+    return
+  }
+
+  if (args[0] === '--print-completions') {
+    printCompletionScript(args[1])
     return
   }
 

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -8,8 +8,7 @@ if type complete &>/dev/null; then
     local cur
     local cword
     _get_comp_words_by_ref -n =: cur words cword
-    IFS=$'\\n'
-    COMPREPLY=($(COMP_CWORD=$cword COMP_LINE=$cur nr --completion \${words[@]}))
+    COMPREPLY=($(COMP_CWORD=$cword COMP_LINE=$cur nr --completion \${words[*]}))
   }
   complete -F _nr_completion nr
 fi

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -1,5 +1,5 @@
-// Print completion script
-export const rawCompletionScript = `
+// Raw completion scripts for bash and zsh
+export const rawBashCompletionScript = `
 ###-begin-nr-completion-###
 
 if type complete &>/dev/null; then
@@ -15,3 +15,30 @@ fi
 
 ###-end-nr-completion-###
 `.trim()
+
+export const rawZshCompletionScript = `
+_nr(){
+  # Set COMP_CWORD to one less than the actual current index (since the first word is the command itself)
+  out=($(COMP_CWORD=$((\${CURRENT} - 1)) COMP_LINE="\${words[@]}" nr --completion "\${words[@]}"))
+  compadd -a out
+}
+
+# don't run the completion function when being source-ed or eval-ed
+if [ "$funcstack[1]" = "_nr" ]; then
+  _nr
+fi
+`.trim()
+
+export function printCompletionScript(shell: string = 'bash') {
+  if (shell === 'bash') {
+    // eslint-disable-next-line no-console
+    console.log(rawBashCompletionScript)
+  }
+  else if (shell === 'zsh') {
+    // eslint-disable-next-line no-console
+    console.log(rawZshCompletionScript)
+  }
+  else {
+    throw new Error(`Unsupported shell '${shell}'`)
+  }
+}


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR introduces support for zsh completions. It adds a new `--print-completions` flag that can be used to print completion scripts for either `bash` or `zsh`. It does retain the current behavior for the `--completion` flag in that it still prints bash completions if no argument is passed. 

It also slightly tweaks how words are passes to `nr --completion` so that it's passed as a string separated sequence and the first argument/word is properly picked up

### Linked Issues
#261 

### Additional context
There is room for future improvement to include script descriptions and customize styling in zsh completions, as well as include completions for other commands like `nun`, `nu` or `na`
<!-- e.g. is there anything you'd like reviewers to focus on? -->
