### PR TITLE
chore: improve script retrieval and add warning for empty scripts

### DIFF
--- a/src/commands/nr.ts
+++ b/src/commands/nr.ts
@@ -13,16 +13,22 @@ import { limitText } from '../utils'
 function readPackageScripts(ctx: RunnerContext | undefined) {
   // support https://www.npmjs.com/package/npm-scripts-info conventions
   const pkg = getPackageJSON(ctx)
-  const scripts = pkg.scripts || {}
+  const rawScripts = pkg.scripts || {}
   const scriptsInfo = pkg['scripts-info'] || {}
 
-  return Object.entries(scripts)
+  const scripts = Object.entries(rawScripts)
     .filter(i => !i[0].startsWith('?'))
     .map(([key, cmd]) => ({
       key,
       cmd,
-      description: scriptsInfo[key] || scripts[`?${key}`] || cmd,
+      description: scriptsInfo[key] || rawScripts[`?${key}`] || cmd,
     }))
+
+  if (scripts.length === 0 && !ctx?.programmatic) {
+    console.warn('No scripts found in package.json')
+  }
+
+  return scripts
 }
 
 runCli(async (agent, args, ctx) => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

我从 codesanbox 下载 zip 到本地后，直接执行 `nr`，控制台什么都没有，虽然这个场景会很小，但是至少可以对其进行一些补充。

<img width="792" alt="image" src="https://github.com/user-attachments/assets/dafde177-710d-4fd9-afa3-e08c0409e3fe" />


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
