### PR TITLE
feat: enable auto-install to be used in all commands (not only `nci`)

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,0 +1,16 @@
+import process from 'node:process'
+
+export interface EnvironmentOptions {
+  autoInstall: boolean
+}
+
+const DEFAULT_ENVIRONMENT_OPTIONS: EnvironmentOptions = {
+  autoInstall: false,
+}
+
+export function getEnvironmentOptions(): EnvironmentOptions {
+  return {
+    ...DEFAULT_ENVIRONMENT_OPTIONS,
+    autoInstall: process.env.NI_AUTO_INSTALL === 'true',
+  }
+}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -11,6 +11,7 @@ import { x } from 'tinyexec'
 import { version } from '../package.json'
 import { getDefaultAgent, getGlobalAgent } from './config'
 import { detect } from './detect'
+import { getEnvironmentOptions } from './environment'
 import { getCommand, UnsupportedCommand } from './parse'
 import { cmdExists, remove } from './utils'
 
@@ -25,6 +26,10 @@ export interface RunnerContext {
 export type Runner = (agent: Agent, args: string[], ctx?: RunnerContext) => Promise<ResolvedCommand | undefined> | ResolvedCommand | undefined
 
 export async function runCli(fn: Runner, options: DetectOptions & { args?: string[] } = {}) {
+  options = {
+    ...getEnvironmentOptions(),
+    ...options,
+  }
   const {
     args = process.argv.slice(2).filter(Boolean),
   } = options

--- a/test/runner/runCli.test.ts
+++ b/test/runner/runCli.test.ts
@@ -1,0 +1,57 @@
+import type { Runner } from '../../src'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { runCli } from '../../src'
+
+// Mock detect to see what options are passed to it
+const mocks = vi.hoisted(() => ({
+  detectSpy: vi.fn(() => Promise.resolve('npm')),
+}))
+vi.mock('../../src/detect', () => ({
+  detect: mocks.detectSpy,
+}))
+
+const baseRunFn: Runner = async () => {
+  return undefined
+}
+
+describe('runCli', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllEnvs()
+  })
+
+  it('run without errors', async () => {
+    const result = await runCli(baseRunFn, {})
+    expect(result).toBe(undefined)
+  })
+
+  it('handle errors in programmatic mode', async () => {
+    await expect(
+      runCli(() => {
+        throw new Error('test error')
+      }, { programmatic: true }),
+    ).rejects.toThrow('test error')
+  })
+
+  it('calls detect with the correct options', async () => {
+    await runCli(baseRunFn)
+    expect(mocks.detectSpy).toHaveBeenCalledWith({ autoInstall: false, cwd: expect.any(String) })
+  })
+
+  it('detects environment options', async () => {
+    vi.stubEnv('NI_AUTO_INSTALL', 'true')
+    await runCli(baseRunFn)
+    expect(mocks.detectSpy).toHaveBeenCalledWith({ autoInstall: true, cwd: expect.any(String) })
+  })
+
+  it('accept options as input', async () => {
+    await runCli(baseRunFn, { autoInstall: true, programmatic: true })
+    expect(mocks.detectSpy).toHaveBeenCalledWith({ autoInstall: true, programmatic: true, cwd: expect.any(String) })
+  })
+
+  it('merges inputs and environment prioritizing inputs', async () => {
+    vi.stubEnv('NI_AUTO_INSTALL', 'true')
+    await runCli(baseRunFn, { autoInstall: false, programmatic: true })
+    expect(mocks.detectSpy).toHaveBeenCalledWith({ autoInstall: false, programmatic: true, cwd: expect.any(String) })
+  })
+})


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

What:
Add a way to turn on `autoInstall` for all commands.
This is a non breaking change that enable users to do something like this.

```bash
NI_AUTO_INSTALL=true nr <my_command>
```

It should work in all commands, but I need this feature specifically in `nr` (to run `nr` in CI without installing the package manager, as I don't know which one will be used)

How:
A new "module" to detect environment variables are added and used in the runner.
The runner now merges the options provided as input with the environment options prioritising the provided input.

I added a little bit of tests also for the runner file, It's not currently testing everything, but considering that there were no test prior to this, it's a starting point.

### Linked Issues

fix https://github.com/antfu-collective/ni/issues/247

### Additional context

I'm not particularly a fan of the test I added as I'm leveraging the mock of `detect` to see what options are being passed down.