### PR TITLE
feat(nr): support -p flag to filter monorepo package in completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ nr
 ```
 
 ```bash
+nr -p
+nr -p dev
+
+# interactively select the package and script to run
+# supports https://www.npmjs.com/package/npm-scripts-info convention
+```
+
+```bash
 nr -
 
 # rerun the last command

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "build": "unbuild",
     "stub": "unbuild --stub",
     "release": "bumpp && pnpm publish",
-    "typecheck": "tsc",
+    "typecheck": "tsc --noEmit",
     "prepare": "npx simple-git-hooks",
     "lint": "eslint",
     "test": "vitest"
@@ -56,7 +56,8 @@
     "ansis": "catalog:prod",
     "fzf": "catalog:prod",
     "package-manager-detector": "catalog:prod",
-    "tinyexec": "catalog:prod"
+    "tinyexec": "catalog:prod",
+    "tinyglobby": "catalog:prod"
   },
   "devDependencies": {
     "@antfu/eslint-config": "catalog:dev",
@@ -71,7 +72,6 @@
     "simple-git-hooks": "catalog:dev",
     "taze": "catalog:dev",
     "terminal-link": "catalog:prod-inlined",
-    "tinyglobby": "catalog:dev",
     "tsx": "catalog:dev",
     "typescript": "catalog:dev",
     "unbuild": "catalog:dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,9 +33,6 @@ catalogs:
     taze:
       specifier: ^19.1.0
       version: 19.1.0
-    tinyglobby:
-      specifier: ^0.2.14
-      version: 0.2.14
     tsx:
       specifier: ^4.19.4
       version: 4.19.4
@@ -61,6 +58,9 @@ catalogs:
     tinyexec:
       specifier: ^1.0.1
       version: 1.0.1
+    tinyglobby:
+      specifier: ^0.2.14
+      version: 0.2.14
   prod-inlined:
     '@posva/prompts':
       specifier: ^2.4.4
@@ -91,6 +91,9 @@ importers:
       tinyexec:
         specifier: catalog:prod
         version: 1.0.1
+      tinyglobby:
+        specifier: catalog:prod
+        version: 0.2.14
     devDependencies:
       '@antfu/eslint-config':
         specifier: catalog:dev
@@ -128,9 +131,6 @@ importers:
       terminal-link:
         specifier: catalog:prod-inlined
         version: 4.0.0
-      tinyglobby:
-        specifier: catalog:dev
-        version: 0.2.14
       tsx:
         specifier: catalog:dev
         version: 4.19.4
@@ -748,51 +748,61 @@ packages:
     resolution: {integrity: sha512-mrA0v3QMy6ZSvEuLs0dMxcO2LnaCONs1Z73GUDBHWbY8tFFocM6yl7YyMu7rz4zS81NDSqhrUuolyZXGi8TEqg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.35.0':
     resolution: {integrity: sha512-DnYhhzcvTAKNexIql8pFajr0PiDGrIsBYPRvCKlA5ixSS3uwo/CWNZxB09jhIapEIg945KOzcYEAGGSmTSpk7A==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.35.0':
     resolution: {integrity: sha512-uagpnH2M2g2b5iLsCTZ35CL1FgyuzzJQ8L9VtlJ+FckBXroTwNOaD0z0/UF+k5K3aNQjbm8LIVpxykUOQt1m/A==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.35.0':
     resolution: {integrity: sha512-XQxVOCd6VJeHQA/7YcqyV0/88N6ysSVzRjJ9I9UA/xXpEsjvAgDTgH3wQYz5bmr7SPtVK2TsP2fQ2N9L4ukoUg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.35.0':
     resolution: {integrity: sha512-5pMT5PzfgwcXEwOaSrqVsz/LvjDZt+vQ8RT/70yhPU06PTuq8WaHhfT1LW+cdD7mW6i/J5/XIkX/1tCAkh1W6g==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.35.0':
     resolution: {integrity: sha512-c+zkcvbhbXF98f4CtEIP1EBA/lCic5xB0lToneZYvMeKu5Kamq3O8gqrxiYYLzlZH6E3Aq+TSW86E4ay8iD8EA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.35.0':
     resolution: {integrity: sha512-s91fuAHdOwH/Tad2tzTtPX7UZyytHIRR6V4+2IGlV0Cej5rkG0R61SX4l4y9sh0JBibMiploZx3oHKPnQBKe4g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.35.0':
     resolution: {integrity: sha512-hQRkPQPLYJZYGP+Hj4fR9dDBMIM7zrzJDWFEMPdTnTy95Ljnv0/4w/ixFw3pTBMEuuEuoqtBINYND4M7ujcuQw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.35.0':
     resolution: {integrity: sha512-Pim1T8rXOri+0HmV4CdKSGrqcBWX0d1HoPnQ0uw0bdp1aP5SdQVNBy8LjYncvnLgu3fnnCt17xjWGd4cqh8/hA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.35.0':
     resolution: {integrity: sha512-QysqXzYiDvQWfUiTm8XmJNO2zm9yC9P/2Gkrwg2dH9cxotQzunBHYr6jk4SujCTqnfGxduOmQcI7c2ryuW8XVg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.35.0':
     resolution: {integrity: sha512-OUOlGqPkVJCdJETKOCEf1mw848ZyJ5w50/rZ/3IBQVdLfR5jk/6Sr5m3iO2tdPgwo0x7VcncYuOvMhBWZq8ayg==}
@@ -931,41 +941,49 @@ packages:
     resolution: {integrity: sha512-jon9M7DKRLGZ9VYSkFMflvNqu9hDtOCEnO2QAryFWgT6o6AXU8du56V7YqnaLKr6rAbZBWYsYpikF226v423QA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.7.2':
     resolution: {integrity: sha512-c8Cg4/h+kQ63pL43wBNaVMmOjXI/X62wQmru51qjfTvI7kmCy5uHTJvK/9LrF0G8Jdx8r34d019P1DVJmhXQpA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.7.2':
     resolution: {integrity: sha512-A+lcwRFyrjeJmv3JJvhz5NbcCkLQL6Mk16kHTNm6/aGNc4FwPHPE4DR9DwuCvCnVHvF5IAd9U4VIs/VvVir5lg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.7.2':
     resolution: {integrity: sha512-hQQ4TJQrSQW8JlPm7tRpXN8OCNP9ez7PajJNjRD1ZTHQAy685OYqPrKjfaMw/8LiHCt8AZ74rfUVHP9vn0N69Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.7.2':
     resolution: {integrity: sha512-NoAGbiqrxtY8kVooZ24i70CjLDlUFI7nDj3I9y54U94p+3kPxwd2L692YsdLa+cqQ0VoqMWoehDFp21PKRUoIQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.7.2':
     resolution: {integrity: sha512-KaZByo8xuQZbUhhreBTW+yUnOIHUsv04P8lKjQ5otiGoSJ17ISGYArc+4vKdLEpGaLbemGzr4ZeUbYQQsLWFjA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.7.2':
     resolution: {integrity: sha512-dEidzJDubxxhUCBJ/SHSMJD/9q7JkyfBMT77Px1npl4xpg9t0POLvnWywSk66BgZS/b2Hy9Y1yFaoMTFJUe9yg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.7.2':
     resolution: {integrity: sha512-RvP+Ux3wDjmnZDT4XWFfNBRVG0fMsc+yVzNFUqOflnDfZ9OYujv6nkh+GOr+watwrW4wdp6ASfG/e7bkDradsw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.7.2':
     resolution: {integrity: sha512-y797JBmO9IsvXVRCKDXOxjyAE4+CcZpla2GSoBQ33TVb3ILXuFnMrbR/QQZoauBYeOFuu4w3ifWLw52sdHGz6g==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,6 @@ catalogs:
     lint-staged: ^16.0.0
     simple-git-hooks: ^2.13.0
     taze: ^19.1.0
-    tinyglobby: ^0.2.14
     tsx: ^4.19.4
     typescript: ^5.8.3
     unbuild: ^3.5.0
@@ -20,6 +19,7 @@ catalogs:
     fzf: ^0.5.2
     package-manager-detector: ^1.3.0
     tinyexec: ^1.0.1
+    tinyglobby: ^0.2.14
   prod-inlined:
     '@posva/prompts': ^2.4.4
     ini: ^5.0.0

--- a/src/monorepo.ts
+++ b/src/monorepo.ts
@@ -1,0 +1,102 @@
+import type { Choice } from '@posva/prompts'
+import type { RunnerContext } from './runner'
+import { existsSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import process from 'node:process'
+import prompts from '@posva/prompts'
+import { byLengthAsc, Fzf } from 'fzf'
+import { globSync } from 'tinyglobby'
+import { getPackageJSON } from './fs'
+
+export const IGNORE_PATHS = [
+  '**/node_modules/**',
+  '**/dist/**',
+  '**/public/**',
+  '**/fixture/**',
+  '**/fixtures/**',
+]
+
+export function findPackages(ctx?: RunnerContext) {
+  const { cwd = process.cwd() } = ctx ?? {}
+  const packagePath = resolve(cwd, 'package.json')
+  if (!existsSync(packagePath))
+    return []
+
+  const pkgs = globSync('**/package.json', {
+    ignore: IGNORE_PATHS,
+    cwd,
+    onlyFiles: true,
+    dot: false,
+    expandDirectories: false,
+  })
+
+  if (pkgs.length <= 1)
+    return [packagePath]
+  return pkgs
+}
+
+export async function promptSelectPackage(ctx?: RunnerContext, command?: string): Promise<RunnerContext | undefined> {
+  const cwd = ctx?.cwd ?? process.cwd()
+  const packagePaths = findPackages(ctx)
+  if (packagePaths.length <= 1) {
+    return ctx
+  }
+
+  const blank = ' '.repeat(process.stdout?.columns || 80)
+  // Prompt the user to select a package
+  let choices: (Choice & { scripts: Record<string, string> })[] = packagePaths.map((item) => {
+    const filePath = resolve(cwd, item)
+    const dir = dirname(filePath)
+    const pkg = getPackageJSON({ ...ctx, cwd: dir, programmatic: true })
+
+    return {
+      title: pkg.name ?? item,
+      value: dir,
+      description: `${pkg.description ?? filePath}${blank}`,
+      scripts: pkg.scripts,
+    }
+  })
+
+  // Filter packages that have the command
+  if (command) {
+    choices = choices.filter(c => c.scripts?.[command])
+  }
+  if (!choices.length) {
+    return ctx
+  }
+  if (choices.length === 1) {
+    return { ...ctx, cwd: choices[0].value }
+  }
+
+  const fzf = new Fzf(choices, {
+    selector: item => `${item.title} ${item.description}`,
+    casing: 'case-insensitive',
+    tiebreakers: [byLengthAsc],
+  })
+
+  let res: string
+  try {
+    const { pkg } = await prompts({
+      name: 'pkg',
+      message: 'select a package',
+      type: 'autocomplete',
+      choices,
+      async suggest(input: string, choices: Choice[]) {
+        if (!input)
+          return choices
+        const results = fzf.find(input)
+        return results.map(r => choices.find(c => c.value === r.item.value))
+      },
+    })
+    if (!pkg)
+      throw new Error('No package selected')
+    res = pkg
+  }
+  catch (error) {
+    if (!ctx?.programmatic)
+      process.exit(1)
+    throw error
+  }
+
+  return { ...ctx, cwd: res }
+}

--- a/src/package.ts
+++ b/src/package.ts
@@ -1,7 +1,34 @@
 import type { RunnerContext } from '.'
 import { getPackageJSON } from './fs'
+import { promptSelectPackage } from './monorepo'
 
-export function readPackageScripts(ctx: RunnerContext | undefined) {
+export interface PackageScript {
+  key: string
+  cmd: string
+  description: string
+}
+
+export async function readWorkspaceScripts(ctx: RunnerContext | undefined, args: string[]): Promise<PackageScript[]> {
+  const index = args.findIndex(i => i === '-p')
+  let command: string = ''
+  if (index !== -1) {
+    command = args[index + 1]
+  }
+
+  const context = await promptSelectPackage(ctx, command)
+  // Change cwd to the selected package
+  if (ctx && context?.cwd) {
+    ctx.cwd = context.cwd
+  }
+  const scripts = readPackageScripts(context)
+  const cmdIndex = scripts.findIndex(i => i.key === command)
+  if (command && cmdIndex !== -1) {
+    return [scripts[cmdIndex]]
+  }
+  return scripts
+}
+
+export function readPackageScripts(ctx: RunnerContext | undefined): PackageScript[] {
   // support https://www.npmjs.com/package/npm-scripts-info conventions
   const pkg = getPackageJSON(ctx)
   const rawScripts = pkg.scripts || {}
@@ -19,5 +46,5 @@ export function readPackageScripts(ctx: RunnerContext | undefined) {
     console.warn('No scripts found in package.json')
   }
 
-  return scripts
+  return scripts as PackageScript[]
 }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -51,7 +51,7 @@ export const parseNi = <Runner>((agent, args, ctx) => {
   return getCommand(agent, 'add', args)
 })
 
-export const parseNr = <Runner>((agent, args) => {
+export const parseNr = <Runner>((agent, args, ctx) => {
   if (args.length === 0)
     args.push('start')
 
@@ -61,7 +61,15 @@ export const parseNr = <Runner>((agent, args) => {
     hasIfPresent = true
   }
 
+  if (args.includes('-p')) {
+    args = exclude(args, '-p')
+  }
+
   const cmd = getCommand(agent, 'run', args)
+  if (ctx?.cwd) {
+    cmd.cwd = ctx.cwd
+  }
+
   if (!cmd)
     return cmd
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,5 +1,5 @@
 import type { Agent, Command, ResolvedCommand } from 'package-manager-detector'
-import type { Runner } from './runner'
+import type { ExtendedResolvedCommand, Runner } from './runner'
 import { COMMANDS, constructCommand } from '.'
 import { exclude } from './utils'
 
@@ -13,7 +13,7 @@ export function getCommand(
   agent: Agent,
   command: Command,
   args: string[] = [],
-): ResolvedCommand {
+): ExtendedResolvedCommand {
   if (!COMMANDS[agent])
     throw new Error(`Unsupported agent "${agent}"`)
   if (!COMMANDS[agent][command])

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -23,7 +23,11 @@ export interface RunnerContext {
   cwd?: string
 }
 
-export type Runner = (agent: Agent, args: string[], ctx?: RunnerContext) => Promise<ResolvedCommand | undefined> | ResolvedCommand | undefined
+export interface ExtendedResolvedCommand extends ResolvedCommand {
+  cwd?: string
+}
+
+export type Runner = (agent: Agent, args: string[], ctx?: RunnerContext) => Promise<ExtendedResolvedCommand | undefined> | ExtendedResolvedCommand | undefined
 
 export async function runCli(fn: Runner, options: DetectOptions & { args?: string[] } = {}) {
   options = {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -165,7 +165,7 @@ export async function run(fn: Runner, args: string[], options: DetectOptions = {
     {
       nodeOptions: {
         stdio: 'inherit',
-        cwd,
+        cwd: command.cwd ?? cwd,
       },
       throwOnError: true,
     },


### PR DESCRIPTION
### Description

This PR adds **monorepo support for the `nr` command**, enabling users to interactively select which package to run scripts from in multi-package repositories.

**Key changes:**
 When multiple packages are detected, shows a searchable/filterable prompt (powered by `fzf`) displaying package names and descriptions. Automatically falls back to single-package behavior when only one package is found

- Moved `tinyglobby` from dev to production dependencies for package discovery
- Added `promptSelectPackage()` function that returns the appropriate `RunnerContext` for the selected package
- Modified `readScripts()` to be async and integrate with package selection

**Impact scope:**
- Affects `nr` command behavior in monorepo environments
<img width="978" height="474" alt="select-package" src="https://github.com/user-attachments/assets/03814d21-6f30-49b5-bd47-3dc492deb129" />
<img width="978" height="474" alt="script-run" src="https://github.com/user-attachments/assets/0b26abf9-59e0-48e2-83e8-e1a5f7d7722c" />

