### PR TITLE
fix(runner): wait for child process before exit on `SIGINT`

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -13,7 +13,7 @@ import { getDefaultAgent, getGlobalAgent } from './config'
 import { detect } from './detect'
 import { getEnvironmentOptions } from './environment'
 import { getCommand, UnsupportedCommand } from './parse'
-import { cmdExists, remove } from './utils'
+import { cmdExists, remove, treeKill } from './utils'
 
 const DEBUG_SIGN = '?'
 
@@ -176,7 +176,14 @@ export async function run(fn: Runner, args: string[], options: DetectOptions = {
   )
 
   process.once('SIGINT', () => {
-    proc.kill('SIGINT')
+    if (proc.pid) {
+      treeKill(proc.pid, 'SIGINT')
+    }
+    else {
+      proc.kill('SIGINT')
+    }
+
+    process.exit(130)
   })
 
   await proc

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -163,7 +163,7 @@ export async function run(fn: Runner, args: string[], options: DetectOptions = {
     return
   }
 
-  await x(
+  const proc = x(
     command.command,
     command.args,
     {
@@ -174,4 +174,10 @@ export async function run(fn: Runner, args: string[], options: DetectOptions = {
       throwOnError: true,
     },
   )
+
+  process.once('SIGINT', () => {
+    proc.kill('SIGINT')
+  })
+
+  await proc
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -13,7 +13,7 @@ import { getDefaultAgent, getGlobalAgent } from './config'
 import { detect } from './detect'
 import { getEnvironmentOptions } from './environment'
 import { getCommand, UnsupportedCommand } from './parse'
-import { cmdExists, remove } from './utils'
+import { cmdExists, remove, treeKill } from './utils'
 
 const DEBUG_SIGN = '?'
 
@@ -163,16 +163,28 @@ export async function run(fn: Runner, args: string[], options: DetectOptions = {
     return
   }
 
-  await x(
+  const proc = x(
     command.command,
     command.args,
     {
       nodeOptions: {
         stdio: 'inherit',
         cwd: command.cwd ?? cwd,
-        detached: true,
       },
       throwOnError: true,
     },
   )
+
+  process.once('SIGINT', () => {
+    if (proc.pid) {
+      treeKill(proc.pid, 'SIGINT')
+    }
+    else {
+      proc.kill('SIGINT')
+    }
+
+    process.exit(130)
+  })
+
+  await proc
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -13,7 +13,7 @@ import { getDefaultAgent, getGlobalAgent } from './config'
 import { detect } from './detect'
 import { getEnvironmentOptions } from './environment'
 import { getCommand, UnsupportedCommand } from './parse'
-import { cmdExists, remove, treeKill } from './utils'
+import { cmdExists, remove } from './utils'
 
 const DEBUG_SIGN = '?'
 
@@ -163,28 +163,16 @@ export async function run(fn: Runner, args: string[], options: DetectOptions = {
     return
   }
 
-  const proc = x(
+  await x(
     command.command,
     command.args,
     {
       nodeOptions: {
         stdio: 'inherit',
         cwd: command.cwd ?? cwd,
+        detached: true,
       },
       throwOnError: true,
     },
   )
-
-  process.once('SIGINT', () => {
-    if (proc.pid) {
-      treeKill(proc.pid, 'SIGINT')
-    }
-    else {
-      proc.kill('SIGINT')
-    }
-
-    process.exit(130)
-  })
-
-  await proc
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -178,7 +178,7 @@ export async function run(fn: Runner, args: string[], options: DetectOptions = {
   process.once('SIGINT', async () => {
     // Ensure the proc finishes cleanup before exiting
     await proc
-    process.exit(130)
+    process.exit(proc.exitCode)
   })
 
   await proc

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -13,7 +13,7 @@ import { getDefaultAgent, getGlobalAgent } from './config'
 import { detect } from './detect'
 import { getEnvironmentOptions } from './environment'
 import { getCommand, UnsupportedCommand } from './parse'
-import { cmdExists, remove, treeKill } from './utils'
+import { cmdExists, remove } from './utils'
 
 const DEBUG_SIGN = '?'
 
@@ -175,14 +175,9 @@ export async function run(fn: Runner, args: string[], options: DetectOptions = {
     },
   )
 
-  process.once('SIGINT', () => {
-    if (proc.pid) {
-      treeKill(proc.pid, 'SIGINT')
-    }
-    else {
-      proc.kill('SIGINT')
-    }
-
+  process.once('SIGINT', async () => {
+    // Ensure the proc finishes cleanup before exiting
+    await proc
     process.exit(130)
   })
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,6 @@
 import type { Buffer } from 'node:buffer'
+import type { KillSignal } from 'tinyexec'
+import { execSync, spawnSync } from 'node:child_process'
 import { existsSync, promises as fs } from 'node:fs'
 import os from 'node:os'
 import { dirname, join } from 'node:path'
@@ -105,4 +107,30 @@ export function formatPackageWithUrl(pkg: string, url?: string, limits = 80) {
         },
       )
     : pkg
+}
+
+export function treeKill(pid: number, signal: KillSignal) {
+  if (process.platform === 'win32') {
+    // use `taskkill` command for Windows
+    execSync(`taskkill /pid ${pid} /T /F`)
+  }
+  else {
+    // Unix-like os
+    const result = process.platform === 'darwin' ? spawnSync('pgrep', ['-P', `${pid}`]) : spawnSync('ps', ['-o', 'pid', '--no-headers', '--ppid', `${pid}`])
+
+    if (result.status === 0 && result.stdout) {
+      const output = result.stdout.toString()
+      const childPids = output.match(/\d+/g)?.map(Number) || []
+      childPids.forEach(childPid => treeKill(childPid, signal))
+    }
+
+    try {
+      process.kill(pid, signal)
+    }
+    catch (err: any) {
+      // ignore if process already dead
+      if (err.code !== 'ESRCH')
+        throw err
+    }
+  }
 }


### PR DESCRIPTION
## Description

### Problem

As the linked issue, long-running process won't stop at once after you send `SIGINT`, it caused by tinyexec's design, the children processes of the main process won't stop and it may interference console interaction.

### Fixes

As a result, we need to kill the children processes to avoid more unexpected output, I used to try making a [`tree-kill`](https://github.com/pkrumins/node-tree-kill) function to solve it, but luckily, nodejs provides `detached` options to do the similar thing with one line's code

## Linked Issues

Close #244

## Addition Content

**~this issue killed half my brain cells lol~**
⬆️ About it's reason

You cannot use `pnpm dev` command to test the solution because `pnpm` may process the `SIGINT`, maybe influenced the output log result

You also cannot use `tsx` commands like `npx tsx src/commands/ni.ts` to test the solution because tsx has the similar problem as #244, it also interference the output log

So you must to build and use `node` command to test the solution
```
pnpm build
node dist/ni.mjs
```

What's more, although `detached` is the easiest way to solve it, but I actuallly do not know if it may cause more unexpected question. If you think that's the case, we can revert to the `tree-kill` function (in the second commit)

**Hope it's helpful**
