### PR TITLE
fix(nr): handle ESC key cancellation in interactive mode

### DIFF
--- a/src/commands/nr.ts
+++ b/src/commands/nr.ts
@@ -35,6 +35,10 @@ runCli(async (agent, args, ctx) => {
       tiebreakers: [byLengthAsc],
     })
 
+    // Workaround for @posva/prompts autocomplete bug where ESC key submits instead of canceling
+    // https://github.com/terkelg/prompts/issues/362
+    let isExited = false
+
     try {
       const { fn } = await prompts({
         name: 'fn',
@@ -47,8 +51,12 @@ runCli(async (agent, args, ctx) => {
           const results = fzf.find(input)
           return results.map(r => choices.find(c => c.value === r.item.key))
         },
+        onState(state) {
+          if (state.exited)
+            isExited = true
+        },
       })
-      if (!fn)
+      if (!fn || isExited)
         process.exit(1)
       args.push(fn)
     }


### PR DESCRIPTION
## Summary

Fixes #236

This PR addresses the issue where pressing ESC during interactive script selection (`nr` command) would execute the currently highlighted script instead of properly canceling the operation.

## Problem

When using `nr` without arguments, an interactive prompt appears to select a script to run. Previously, pressing ESC would:
- Display a yellow `✖` symbol (suggesting cancellation)
- But still execute the highlighted script (incorrect behavior)

This was caused by a known bug in the `@posva/prompts` library where the ESC key submits the current selection rather than canceling (see [terkelg/prompts#362](https://github.com/terkelg/prompts/issues/362)).

## Solution

Added an `isExited` flag that tracks when the user presses ESC via the `onState` callback. The script now properly exits when `isExited` is true.

## Test Plan

1. Run `nr` (or `pnpm nr` in this repo)
2. Press ESC without selecting anything
3. Verify the process exits without running any script
4. Run `nr` again
5. Press Enter to select a script
6. Verify the script runs normally

## Related

- Upstream issue: https://github.com/terkelg/prompts/issues/362