### PR TITLE
feat(nr): add Fish shell completion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ mkdir -p ~/.zim/custom/ni-completions
 nr --completion-zsh > ~/.zim/custom/ni-completions/_ni
 echo "zmodule $HOME/.zim/custom/ni-completions --fpath ." >> ~/.zimrc
 zimfw install
+
+# Add completion script for fish
+mkdir -p ~/.config/fish/completions
+nr --completion-fish > ~/.config/fish/completions/ni.fish
 ```
 
 <br>

--- a/src/commands/nr.ts
+++ b/src/commands/nr.ts
@@ -3,7 +3,7 @@ import type { PackageScript } from '../package'
 import process from 'node:process'
 import prompts from '@posva/prompts'
 import { byLengthAsc, Fzf } from 'fzf'
-import { getCompletionSuggestions, rawBashCompletionScript, rawZshCompletionScript } from '../completion'
+import { getCompletionSuggestions, rawBashCompletionScript, rawFishCompletionScript, rawZshCompletionScript } from '../completion'
 import { readPackageScripts, readWorkspaceScripts } from '../package'
 import { parseNr } from '../parse'
 import { runCli } from '../runner'
@@ -103,6 +103,13 @@ runCli(async (agent, args, ctx) => {
   if (args[0] === '--completion-bash') {
     // eslint-disable-next-line no-console
     console.log(rawBashCompletionScript)
+    return
+  }
+
+  // Print Fish completion script
+  if (args[0] === '--completion-fish') {
+    // eslint-disable-next-line no-console
+    console.log(rawFishCompletionScript)
     return
   }
 

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -34,6 +34,104 @@ _nr_completion() {
 _nr_completion
 `.trim()
 
+export const rawFishCompletionScript = `
+function __nr_fish_scripts
+  set -l tokens (commandline -xpc)
+  set -l cwd_option
+  set -l other_options
+  set -l query_tokens
+
+  # drop the command name
+  if test (count $tokens) -ge 1
+    set tokens $tokens[2..-1]
+  end
+
+  # Separate -C option, other options, and query tokens
+  set -l skip_next 0
+  for token in $tokens
+    if test $skip_next -eq 1
+      # This is the argument to -C
+      set -a cwd_option $token
+      set skip_next 0
+      continue
+    end
+
+    if test "$token" = "-C"
+      set -a cwd_option $token
+      set skip_next 1
+      continue
+    end
+
+    # Other options that don't take arguments
+    if string match -qr '^-' -- $token
+      set -a other_options $token
+    else
+      # Non-option tokens are part of the query
+      set -a query_tokens $token
+    end
+  end
+
+  # Call nr with correct order: -C first (processed by runCli), then --completion, then query, then other options
+  nr $cwd_option --completion $query_tokens $other_options 2>/dev/null
+end
+
+function __nr_needs_script_completion
+  # Don't complete if completion-related options are present
+  if __fish_seen_argument -l completion -l completion-bash -l completion-zsh -l completion-fish
+    return 1
+  end
+
+  # Don't complete if -p option is present (workspace selection)
+  if __fish_seen_argument -s p
+    return 1
+  end
+
+  set -l tokens (commandline -xpc)
+  set -l cmd (commandline -ct)
+
+  # Remove command name
+  set -e tokens[1]
+
+  # Check if any non-option argument exists (excluding -C's directory argument)
+  set -l skip_next 0
+  for token in $tokens
+    # Skip this token if it's the argument to -C
+    if test $skip_next -eq 1
+      set skip_next 0
+      continue
+    end
+
+    # If token is -C, skip the next token (its directory argument)
+    if test "$token" = "-C"
+      set skip_next 1
+      continue
+    end
+
+    # If we find a token that doesn't start with -, a script name is already provided
+    if not string match -qr '^-' -- $token
+      return 1
+    end
+  end
+
+  # Only complete if current token is not an option
+  not string match -qr '^-' -- $cmd
+end
+
+# Define completions for nr command
+complete -c nr -e
+complete -c nr -f
+complete -c nr -s h -l help -d 'Show help'
+complete -c nr -s v -l version -d 'Show version'
+complete -c nr -s C -d 'Change working directory' -r -a '(__fish_complete_directories)'
+complete -c nr -l completion -d 'Print script suggestions' -f
+complete -c nr -l completion-bash -d 'Print Bash completions' -f
+complete -c nr -l completion-zsh -d 'Print Zsh completions' -f
+complete -c nr -l completion-fish -d 'Print Fish completions' -f
+complete -c nr -l if-present -d 'Ignore missing scripts'
+complete -c nr -s p -d 'Select workspace package before running'
+complete -c nr -n '__nr_needs_script_completion' -a '(__nr_fish_scripts)' -d 'package.json scripts'
+`.trim()
+
 export function getCompletionSuggestions(args: string[], ctx: RunnerContext | undefined) {
   const raw = readPackageScripts(ctx)
   const fzf = new Fzf(raw, {


### PR DESCRIPTION
### Summary

This PR adds Fish shell completion for the `nr` command, matching the functionality provided by existing Bash/Zsh completions.

**Key features:**
- ✅ Script completion from `package.json` via `nr --completion`
- ✅ Option completion (--help, --version, -C, etc.)
- ✅ No external dependencies (Fish builtins only)
- ✅ All 415 tests passing

### Background

Previously, `ni` only provided shell completions for Bash and Zsh users. This PR adds Fish shell support, bringing the same completion experience to Fish users.

### Implementation

1. **Added Fish completion script** (`src/completion.ts`)
   - New `rawFishCompletionScript` template for `nr` command
   - Uses `nr --completion` for script suggestions (consistent with Bash/Zsh)

2. **Added `--completion-fish` flag** (`src/commands/nr.ts`)
   - Parallel to existing `--completion-bash` and `--completion-zsh`
   - Outputs Fish completion script for installation

3. **Updated documentation** (`README.md`)
   - Installation instructions for Fish

### Installation

Users can install Fish completion with:

```bash
mkdir -p ~/.config/fish/completions
nr --completion-fish > ~/.config/fish/completions/ni.fish
```

### Additional Context

#### Why Fish Implementation Differs from Bash/Zsh

The Fish completion is more verbose (~115 lines vs ~60 for Bash/Zsh combined) due to fundamental differences in shell design:

**1. Option definitions included**
- Bash/Zsh: No option completion (e.g., `nr --<TAB>` shows nothing)
- Fish: Provides option completion for better UX (--help, --version, -C, etc.)

**2. Option handling logic required**
- Bash/Zsh: `nr -C /tmp <TAB>` is broken (passes `-C` as query to `nr --completion`)
- Fish: Properly separates `-C` option, other options, and query tokens, ensuring correct execution order (`nr -C <path> --completion <query> <other_options>`)

**3. Explicit definitions vs. implicit behavior**
- Bash/Zsh: Delegates to shell's built-in completion system
- Fish: Requires explicit `complete` definitions for all behavior

These additions provide Fish users with a more polished experience while maintaining feature parity with Bash/Zsh for core functionality (script completion).

#### Technical Details

- Fish completion uses only Fish builtins (`complete`, `commandline`, etc.)
- Falls back gracefully when `package.json` is missing (null check in `readPackageScripts`)
- Script completion is dynamically generated from `package.json` scripts via `nr --completion`
- Option parsing in `__nr_fish_scripts` correctly orders arguments:
  - `-C <path>` is placed first (processed by `runner.ts`)
  - `--completion` follows (triggers completion mode in `nr.ts`)
  - Query tokens and other options follow in order
  - This ensures `nr.ts:70` check (`args[0] === '--completion'`) succeeds after `-C` processing

### Related

This implementation follows the same patterns as:
- #241 (feat: add bash completion)
- #285 (feat: support zsh completion)