### PR TITLE
fix(nr): correct node --run command structure

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -65,6 +65,7 @@ export const parseNr = <Runner>(async (agent, args, ctx) => {
       throw new Error('The runAgent "node" requires Node.js 22.0.0 or higher')
     }
     runWithNode = true
+    args = ['--run', ...args]
   }
 
   let hasIfPresent = false
@@ -76,7 +77,7 @@ export const parseNr = <Runner>(async (agent, args, ctx) => {
   if (args.includes('-p'))
     args = exclude(args, '-p')
 
-  const cmd = runWithNode ? { command: 'node --run', args } : getCommand(agent, 'run', args)
+  const cmd = runWithNode ? { command: 'node', args } : getCommand(agent, 'run', args)
 
   if (ctx?.cwd)
     cmd.cwd = ctx.cwd

--- a/test/nr/nodeRunAgent.spec.ts
+++ b/test/nr/nodeRunAgent.spec.ts
@@ -1,15 +1,16 @@
+import type { ResolvedCommand } from 'package-manager-detector'
 import { beforeEach, expect, it, vi } from 'vitest'
-import { parseNr, serializeCommand } from '../../src/commands'
+import { parseNr } from '../../src/commands'
 
 const agent = 'npm'
 const [majorNodeVersion] = process.versions.node.split('.').map(Number)
 const supportsNodeRun = majorNodeVersion >= 22
 
-function _(arg: string, expected: string) {
+function _(arg: string, expected: ResolvedCommand) {
   return async () => {
     expect(
-      serializeCommand(await parseNr(agent, arg.split(' ').filter(Boolean))),
-    ).toBe(
+      await parseNr(agent, arg.split(' ').filter(Boolean)),
+    ).toEqual(
       expected,
     )
   }
@@ -27,12 +28,12 @@ beforeEach(() => {
   vi.stubEnv('NI_RUN_AGENT', 'node')
 })
 
-it('empty', supportsNodeRun ? _('', 'node --run start') : expectError(''))
+it('empty', supportsNodeRun ? _('', { command: 'node', args: ['--run', 'start'] }) : expectError(''))
 
-it('if-present', supportsNodeRun ? _('test --if-present', 'node --run test') : expectError('test --if-present'))
+it('if-present', supportsNodeRun ? _('test --if-present', { command: 'node', args: ['--run', 'test'] }) : expectError('test --if-present'))
 
-it('script', supportsNodeRun ? _('dev', 'node --run dev') : expectError('dev'))
+it('script', supportsNodeRun ? _('dev', { command: 'node', args: ['--run', 'dev'] }) : expectError('dev'))
 
-it('script with arguments', supportsNodeRun ? _('build --watch -o', 'node --run build --watch -o') : expectError('build --watch -o'))
+it('script with arguments', supportsNodeRun ? _('build --watch -o', { command: 'node', args: ['--run', 'build', '--watch', '-o'] }) : expectError('build --watch -o'))
 
-it('colon', supportsNodeRun ? _('build:dev', 'node --run build:dev') : expectError('build:dev'))
+it('colon', supportsNodeRun ? _('build:dev', { command: 'node', args: ['--run', 'build:dev'] }) : expectError('build:dev'))


### PR DESCRIPTION
## Problem

When using `node` as the run agent, the `--run` flag was incorrectly concatenated into the command string, resulting in:

```js
{ command: 'node --run', args: ['start'] }
```

This structure is inconsistent with how other commands are built and can cause issues during command serialization and execution.

## Solution

Move the --run flag into the args array, producing the correct structure:

```js
{ command: 'node', args: ['--run', 'start'] }
```