### PR TITLE
fix: workspace flag parsing in nr command

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -77,6 +77,23 @@ export const parseNr = <Runner>(async (agent, args, ctx) => {
   if (args.includes('-p'))
     args = exclude(args, '-p')
 
+  // Fix workspace flag parsing: merge `-w value` or `--workspace value` into `-w=value` or `--workspace=value`
+  // to prevent npm from interpreting the flag as boolean true
+  const processedArgs: string[] = []
+  let i = 0
+  while (i < args.length) {
+    const arg = args[i]
+    if ((arg === '-w' || arg === '--workspace') && i + 1 < args.length && !args[i + 1].startsWith('-')) {
+      processedArgs.push(`${arg}=${args[i + 1]}`)
+      i += 2
+    }
+    else {
+      processedArgs.push(arg)
+      i++
+    }
+  }
+  args = processedArgs
+
   const cmd = runWithNode ? { command: 'node', args } : getCommand(agent, 'run', args)
 
   if (ctx?.cwd)

--- a/test/nr/npm.spec.ts
+++ b/test/nr/npm.spec.ts
@@ -21,3 +21,16 @@ it('script', _('dev', 'npm run dev'))
 it('script with arguments', _('build --watch -o', 'npm run build -- --watch -o'))
 
 it('colon', _('build:dev', 'npm run build:dev'))
+
+// https://github.com/antfu-collective/ni/issues/322
+it('workspace flag before script', _('-w packages/foo test', 'npm run -w=packages/foo -- test'))
+
+it('workspace long flag before script', _('--workspace packages/foo test', 'npm run --workspace=packages/foo -- test'))
+
+it('workspace flag after script', _('test -w packages/foo', 'npm run test -- -w=packages/foo'))
+
+it('workspace long flag after script', _('test --workspace packages/foo', 'npm run test -- --workspace=packages/foo'))
+
+it('workspace flag already joined with equals', _('-w=packages/foo test', 'npm run -w=packages/foo -- test'))
+
+it('trailing workspace flag without value', _('test -w', 'npm run test -- -w'))

--- a/test/nr/pnpm.spec.ts
+++ b/test/nr/pnpm.spec.ts
@@ -21,3 +21,8 @@ it('script', _('dev', 'pnpm run dev'))
 it('script with arguments', _('build --watch -o', 'pnpm run build --watch -o'))
 
 it('colon', _('build:dev', 'pnpm run build:dev'))
+
+// https://github.com/antfu-collective/ni/issues/322
+it('workspace flag before script', _('-w packages/foo test', 'pnpm run -w=packages/foo test'))
+
+it('workspace long flag after script', _('test --workspace packages/foo', 'pnpm run test --workspace=packages/foo'))

--- a/test/nr/yarn.spec.ts
+++ b/test/nr/yarn.spec.ts
@@ -21,3 +21,6 @@ it('script', _('dev', 'yarn run dev'))
 it('script with arguments', _('build --watch -o', 'yarn run build --watch -o'))
 
 it('colon', _('build:dev', 'yarn run build:dev'))
+
+// https://github.com/antfu-collective/ni/issues/322
+it('workspace flag before script', _('-w packages/foo test', 'yarn run -w=packages/foo test'))


### PR DESCRIPTION
## Summary

Fixes a bug where the `-w` or `--workspace` flag without `=` did not work in the `nr` command for npm.

## Problem

```bash
nr -w packages/foo test  # Failed with --workspace=true
nr -w=packages/foo test  # Worked
```

Other commands (ni, nlx, nun, nup, nci, nd) worked correctly with `-w packages/foo`, only `nr` had this issue.

## Root Cause

The workspace flag value was being parsed as boolean `true` instead of accepting the next argument as the workspace path.

## Fix

Updated the argument parsing in the nr command to match the behavior of other commands by merging `-w value` into `-w=value` format before passing to the package manager.

## Testing

- Manual testing with npm workspaces
- Verified all package managers (npm, pnpm, yarn, bun)

Fixes antfu-collective/ni#322