### PR TITLE
feat: add --agent flag to print detected package manager name

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -152,6 +152,18 @@ export async function run(fn: Runner, args: string[], options: DetectOptions & R
     return
   }
 
+  if (args.length === 1 && args[0] === '--agent') {
+    const isGlobal = args.includes('-g')
+    const agent = isGlobal
+      ? await getGlobalAgent()
+      : (await detect({ ...options, cwd })) || (await getDefaultAgent(programmatic))
+    if (agent && agent !== 'prompt')
+      process.stdout.write(`${agent}\n`)
+    else
+      process.stdout.write('unknown\n')
+    return
+  }
+
   if (args.length === 1 && ['-h', '--help'].includes(args[0])) {
     const dash = styleText('dim', '-')
     console.log(`${styleText(['green', 'bold'], '@antfu/ni')} ${styleText('dim', `use the right package manager v${version}`)}\n`)
@@ -163,7 +175,8 @@ export async function run(fn: Runner, args: string[], options: DetectOptions & R
     console.log(`nci   ${dash}  clean install`)
     console.log(`na    ${dash}  agent alias`)
     console.log(`nd    ${dash}  dedupe dependencies`)
-    console.log(`ni -v ${dash}  show used agent`)
+    console.log(`ni -v       ${dash}  show used agent`)
+    console.log(`ni --agent  ${dash}  print detected agent name (for scripting)`)
     console.log(`ni -i ${dash}  interactive package management`)
     console.log(styleText('yellow', '\ncheck https://github.com/antfu/ni for more documentation.'))
     return


### PR DESCRIPTION
Closes #326

## Problem

There's no way to get just the detected package manager name from `ni` without parsing the full `ni -v` table output. This makes it awkward to use in CI pipelines and shell scripts where you need the bare agent name for conditional logic.

## Solution

Adds a `--agent` flag that prints only the detected package manager name to stdout — no colors, no version info, just the agent name followed by a newline.

```sh
$ ni --agent
pnpm

$ ni --agent
bun
```

Works with any `ni` command since it's handled in the runner before agent-specific logic runs. Prints `unknown` if no lock file is found and no default is configured.

Also updated the help output (`ni -h`) to document the new flag.

## Use case

```sh
# capture in a variable
PM=$(ni --agent)

# use in CI conditionals
if [ "$(ni --agent)" = "pnpm" ]; then
  pnpm install --frozen-lockfile
fi
```