### PR TITLE
feat(nr): add noLastCommand config option

### DIFF
--- a/src/commands/nr.ts
+++ b/src/commands/nr.ts
@@ -4,10 +4,10 @@ import process from 'node:process'
 import prompts from '@posva/prompts'
 import { byLengthAsc, Fzf } from 'fzf'
 import { getCompletionSuggestions, rawBashCompletionScript, rawFishCompletionScript, rawZshCompletionScript } from '../completion'
+import { getConfig } from '../config'
 import { readPackageScripts, readWorkspaceScripts } from '../package'
 import { parseNr } from '../parse'
 import { runCli } from '../runner'
-import { getConfig } from '../config'
 import { dump, load } from '../storage'
 import { limitText } from '../utils'
 
@@ -18,14 +18,14 @@ runCli(async (agent, args, ctx) => {
     const terminalColumns = process.stdout?.columns || 80
 
     const last = storage.lastRunCommand
-    const { hideLastCommand } = await getConfig()
+    const { noLastCommand } = await getConfig()
     const choices = raw.reduce<Choice[]>((acc, { key, description }) => {
       const item = {
         title: key,
         value: key,
         description: limitText(description, terminalColumns - 15),
       }
-      if (!hideLastCommand && last && key === last) {
+      if (!noLastCommand && last && key === last) {
         return [item, ...acc]
       }
       return [...acc, item]

--- a/src/commands/nr.ts
+++ b/src/commands/nr.ts
@@ -7,6 +7,7 @@ import { getCompletionSuggestions, rawBashCompletionScript, rawFishCompletionScr
 import { readPackageScripts, readWorkspaceScripts } from '../package'
 import { parseNr } from '../parse'
 import { runCli } from '../runner'
+import { getConfig } from '../config'
 import { dump, load } from '../storage'
 import { limitText } from '../utils'
 
@@ -17,13 +18,14 @@ runCli(async (agent, args, ctx) => {
     const terminalColumns = process.stdout?.columns || 80
 
     const last = storage.lastRunCommand
+    const { hideLastCommand } = await getConfig()
     const choices = raw.reduce<Choice[]>((acc, { key, description }) => {
       const item = {
         title: key,
         value: key,
         description: limitText(description, terminalColumns - 15),
       }
-      if (last && key === last) {
+      if (!hideLastCommand && last && key === last) {
         return [item, ...acc]
       }
       return [...acc, item]

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,7 @@ interface Config {
   runAgent: 'node' | undefined
   useSfw: boolean
   catalog: boolean
-  hideLastCommand: boolean
+  noLastCommand: boolean
 }
 
 const defaultConfig: Config = {
@@ -30,7 +30,7 @@ const defaultConfig: Config = {
   runAgent: undefined,
   useSfw: false,
   catalog: true,
-  hideLastCommand: false,
+  noLastCommand: false,
 }
 
 let config: Config | undefined
@@ -56,8 +56,8 @@ export async function getConfig(): Promise<Config> {
     if (process.env.NI_CATALOG !== undefined)
       config.catalog = process.env.NI_CATALOG !== 'false'
 
-    if (process.env.NI_HIDE_LAST_COMMAND !== undefined)
-      config.hideLastCommand = process.env.NI_HIDE_LAST_COMMAND === 'true'
+    if (process.env.NI_NO_LAST_COMMAND !== undefined)
+      config.noLastCommand = process.env.NI_NO_LAST_COMMAND === 'true'
 
     const agent = await detect({ programmatic: true })
     if (agent)

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,7 @@ interface Config {
   runAgent: 'node' | undefined
   useSfw: boolean
   catalog: boolean
+  hideLastCommand: boolean
 }
 
 const defaultConfig: Config = {
@@ -29,6 +30,7 @@ const defaultConfig: Config = {
   runAgent: undefined,
   useSfw: false,
   catalog: true,
+  hideLastCommand: false,
 }
 
 let config: Config | undefined
@@ -53,6 +55,9 @@ export async function getConfig(): Promise<Config> {
 
     if (process.env.NI_CATALOG !== undefined)
       config.catalog = process.env.NI_CATALOG !== 'false'
+
+    if (process.env.NI_HIDE_LAST_COMMAND !== undefined)
+      config.hideLastCommand = process.env.NI_HIDE_LAST_COMMAND === 'true'
 
     const agent = await detect({ programmatic: true })
     if (agent)

--- a/test/config/config.test.ts
+++ b/test/config/config.test.ts
@@ -23,6 +23,7 @@ it('has correct defaults', async () => {
     runAgent: undefined,
     useSfw: false,
     catalog: true,
+    hideLastCommand: false,
   })
 })
 
@@ -38,6 +39,7 @@ it('loads .nirc', async () => {
     runAgent: undefined,
     useSfw: true,
     catalog: true,
+    hideLastCommand: false,
   })
 })
 
@@ -55,5 +57,24 @@ it('reads environment variable config', async () => {
     runAgent: undefined,
     useSfw: true,
     catalog: true,
+    hideLastCommand: false,
   })
+})
+
+it('enables hideLastCommand via NI_HIDE_LAST_COMMAND env var', async () => {
+  vi.stubEnv('NI_HIDE_LAST_COMMAND', 'true')
+
+  const { getConfig } = await import('../../src/config')
+  const config = await getConfig()
+
+  expect(config.hideLastCommand).toBe(true)
+})
+
+it('keeps hideLastCommand false when NI_HIDE_LAST_COMMAND is not "true"', async () => {
+  vi.stubEnv('NI_HIDE_LAST_COMMAND', 'false')
+
+  const { getConfig } = await import('../../src/config')
+  const config = await getConfig()
+
+  expect(config.hideLastCommand).toBe(false)
 })

--- a/test/config/config.test.ts
+++ b/test/config/config.test.ts
@@ -23,7 +23,7 @@ it('has correct defaults', async () => {
     runAgent: undefined,
     useSfw: false,
     catalog: true,
-    hideLastCommand: false,
+    noLastCommand: false,
   })
 })
 
@@ -39,7 +39,7 @@ it('loads .nirc', async () => {
     runAgent: undefined,
     useSfw: true,
     catalog: true,
-    hideLastCommand: false,
+    noLastCommand: false,
   })
 })
 
@@ -57,24 +57,24 @@ it('reads environment variable config', async () => {
     runAgent: undefined,
     useSfw: true,
     catalog: true,
-    hideLastCommand: false,
+    noLastCommand: false,
   })
 })
 
-it('enables hideLastCommand via NI_HIDE_LAST_COMMAND env var', async () => {
-  vi.stubEnv('NI_HIDE_LAST_COMMAND', 'true')
+it('enables noLastCommand via NI_NO_LAST_COMMAND env var', async () => {
+  vi.stubEnv('NI_NO_LAST_COMMAND', 'true')
 
   const { getConfig } = await import('../../src/config')
   const config = await getConfig()
 
-  expect(config.hideLastCommand).toBe(true)
+  expect(config.noLastCommand).toBe(true)
 })
 
-it('keeps hideLastCommand false when NI_HIDE_LAST_COMMAND is not "true"', async () => {
-  vi.stubEnv('NI_HIDE_LAST_COMMAND', 'false')
+it('keeps noLastCommand false when NI_NO_LAST_COMMAND is not "true"', async () => {
+  vi.stubEnv('NI_NO_LAST_COMMAND', 'false')
 
   const { getConfig } = await import('../../src/config')
   const config = await getConfig()
 
-  expect(config.hideLastCommand).toBe(false)
+  expect(config.noLastCommand).toBe(false)
 })


### PR DESCRIPTION
## What

Adds a `hideLastCommand` config option (default: `false`) and a corresponding
`NI_HIDE_LAST_COMMAND` environment variable.

When enabled, `nr` will no longer pin the most recently used script to the top
of the prompt list — the list stays in its natural alphabetical / insertion order.

## Why

Some users prefer a consistent, stable ordering in the `nr` prompt and find the
"last used first" behaviour disruptive to their workflow.

Fixes #315

## Changes

- `src/config.ts` — added `hideLastCommand: boolean` to `Config` interface and
  default config (`false`); reads `NI_HIDE_LAST_COMMAND` env var
- `src/commands/nr.ts` — skips prepending last command when `hideLastCommand` is `true`
- `test/config/config.test.ts` — updated existing assertions to include
  `hideLastCommand: false`; added two new tests for the env var

## Usage

Via `.nirc`:
```ini
hideLastCommand=true
```

Via environment variable:
```sh
NI_HIDE_LAST_COMMAND=true nr
```
