### PR TITLE
fix: preserve forwarded -p args in nr

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -56,6 +56,9 @@ export const parseNr = <Runner>(async (agent, args, ctx) => {
   if (args.length === 0)
     args.push('start')
 
+  if (args[0] === '-p')
+    args = args.slice(1)
+
   const runAgent = await getRunAgent()
 
   let runWithNode = false
@@ -73,9 +76,6 @@ export const parseNr = <Runner>(async (agent, args, ctx) => {
     args = exclude(args, '--if-present')
     hasIfPresent = true
   }
-
-  if (args.includes('-p'))
-    args = exclude(args, '-p')
 
   // Fix workspace flag parsing: merge `-w value` or `--workspace value` into `-w=value` or `--workspace=value`
   // to prevent npm from interpreting the flag as boolean true

--- a/test/nr/bun.spec.ts
+++ b/test/nr/bun.spec.ts
@@ -18,4 +18,10 @@ it('script', _('dev', 'bun run dev'))
 
 it('script with arguments', _('build --watch -o', 'bun run build --watch -o'))
 
+it('leading monorepo flag is stripped', _('-p dev', 'bun run dev'))
+
+it('preserves -p after the script name', _('dev -p', 'bun run dev -p'))
+
+it('preserves -p after other forwarded args', _('dev --watch -p', 'bun run dev --watch -p'))
+
 it('colon', _('build:dev', 'bun run build:dev'))

--- a/test/nr/nodeRunAgent.spec.ts
+++ b/test/nr/nodeRunAgent.spec.ts
@@ -34,6 +34,8 @@ it('if-present', supportsNodeRun ? _('test --if-present', { command: 'node', arg
 
 it('script', supportsNodeRun ? _('dev', { command: 'node', args: ['--run', 'dev'] }) : expectError('dev'))
 
+it('leading monorepo flag is stripped', supportsNodeRun ? _('-p dev', { command: 'node', args: ['--run', 'dev'] }) : expectError('-p dev'))
+
 it('script with arguments', supportsNodeRun ? _('build --watch -o', { command: 'node', args: ['--run', 'build', '--watch', '-o'] }) : expectError('build --watch -o'))
 
 it('colon', supportsNodeRun ? _('build:dev', { command: 'node', args: ['--run', 'build:dev'] }) : expectError('build:dev'))


### PR DESCRIPTION
fixes #332

## why

`parseNr()` treated every `-p` as the monorepo selector flag, so forwarded `-p` args were dropped even when they came after the script name.

## what changed

- only consume a leading `-p` before building the run command
- keep forwarded `-p` args intact
- add regression coverage for bun and `NI_RUN_AGENT=node`

## test plan

- `pnpm vitest run test/nr/*.spec.ts`