### PR TITLE
feat(nr): ctrl+j / ctrl+k to navigate the script picker (fzf style)

### DIFF
--- a/src/commands/nr.ts
+++ b/src/commands/nr.ts
@@ -41,6 +41,23 @@ runCli(async (agent, args, ctx) => {
     // https://github.com/terkelg/prompts/issues/362
     let isExited = false
 
+    // Add fzf-style Ctrl+J/Ctrl+K navigation. Mutates the key object before the
+    // prompt's own keypress handler runs, so the library sees a regular up/down.
+    // Ctrl+J arrives as { name: 'enter' } (terminals send \r for Enter, so this
+    // doesn't conflict). Ctrl+K arrives as { name: 'k', ctrl: true }.
+    const fzfKeyHandler = (_str: string, key: { name?: string, ctrl?: boolean }) => {
+      if (!key)
+        return
+      if (key.ctrl && key.name === 'k') {
+        key.ctrl = false
+        key.name = 'up'
+      }
+      else if (!key.ctrl && key.name === 'enter') {
+        key.name = 'down'
+      }
+    }
+    process.stdin.prependListener('keypress', fzfKeyHandler)
+
     try {
       const { fn } = await prompts({
         name: 'fn',
@@ -64,6 +81,9 @@ runCli(async (agent, args, ctx) => {
     }
     catch {
       process.exit(1)
+    }
+    finally {
+      process.stdin.removeListener('keypress', fzfKeyHandler)
     }
   }
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves #336 

### 🧭 Context

the `nr` picker only supports arrows (and ctrl+p/ctrl+n) for navigating the list. coming from fzf/vim, ctrl+j / ctrl+k is the muscle memory people reach for.

### 📚 Description

binds ctrl+j → down and ctrl+k → up in the autocomplete prompt, matching fzf.

done by prepending a `keypress` listener on stdin that rewrites the key before `@posva/prompts` handles it:
- ctrl+k arrives as `{ name: 'k', ctrl: true }` → rewritten to `up`
- ctrl+j arrives as `{ name: 'enter' }` (terminals send `\r` for the actual enter key, not `\n`, so there's no conflict) → rewritten to `down`

the listener is removed in a `finally` so it doesn't leak into anything else. no new deps, no config flag.  just on by default since it's purely additive (arrows, ctrl+p/n, and enter all keep working as before).
