### PR TITLE
feat: support yarn catalogs

### DIFF
--- a/src/catalog/detect.ts
+++ b/src/catalog/detect.ts
@@ -1,9 +1,12 @@
 import type { Agent } from 'package-manager-detector'
 import type { CatalogProvider } from './types'
 import { pnpmCatalogProvider } from './pnpm'
+import { yarnCatalogProvider } from './yarn'
 
 export function getCatalogProvider(agent: Agent): CatalogProvider | null {
   if (agent === 'pnpm')
     return pnpmCatalogProvider
+  if (agent === 'yarn@berry')
+    return yarnCatalogProvider
   return null
 }

--- a/src/catalog/yarn.ts
+++ b/src/catalog/yarn.ts
@@ -1,0 +1,76 @@
+import type { CatalogConfig, CatalogInfo, CatalogProvider } from './types'
+import fs from 'node:fs'
+import path from 'node:path'
+import { parsePnpmWorkspaceYaml } from 'pnpm-workspace-yaml'
+
+function findYarnRcYaml(cwd: string): string | null {
+  let dir = path.resolve(cwd)
+  while (true) {
+    const filePath = path.join(dir, '.yarnrc.yml')
+    if (fs.existsSync(filePath))
+      return filePath
+    const parent = path.dirname(dir)
+    if (parent === dir)
+      return null
+    dir = parent
+  }
+}
+
+export const yarnCatalogProvider: CatalogProvider = {
+  async detect(cwd: string): Promise<CatalogConfig | null> {
+    const filePath = findYarnRcYaml(cwd)
+    if (!filePath)
+      return null
+
+    const content = fs.readFileSync(filePath, 'utf-8')
+    const workspace = parsePnpmWorkspaceYaml(content)
+    const json = workspace.toJSON()
+
+    const catalogs: CatalogInfo[] = []
+    const hasDefaultCatalog = json.catalog != null && Object.keys(json.catalog).length > 0
+    const hasNamedCatalogs = json.catalogs != null && Object.keys(json.catalogs).length > 0
+
+    if (!hasDefaultCatalog && !hasNamedCatalogs)
+      return null
+
+    if (hasDefaultCatalog) {
+      catalogs.push({
+        name: 'default',
+        packages: json.catalog!,
+      })
+    }
+
+    if (hasNamedCatalogs) {
+      for (const [name, packages] of Object.entries(json.catalogs!)) {
+        catalogs.push({ name, packages })
+      }
+    }
+
+    return {
+      filePath,
+      catalogs,
+      hasDefaultCatalog,
+      hasNamedCatalogs,
+    }
+  },
+
+  findPackage(config: CatalogConfig, pkgName: string): CatalogInfo | undefined {
+    return config.catalogs.find(c => pkgName in c.packages)
+  },
+
+  async addPackage(config: CatalogConfig, catalogName: string, pkgName: string, version: string): Promise<void> {
+    const content = fs.readFileSync(config.filePath, 'utf-8')
+    const workspace = parsePnpmWorkspaceYaml(content)
+    workspace.setPackage(catalogName, pkgName, version)
+    fs.writeFileSync(config.filePath, workspace.toString())
+
+    // Update the in-memory config
+    const existing = config.catalogs.find(c => c.name === catalogName)
+    if (existing) {
+      existing.packages[pkgName] = version
+    }
+    else {
+      config.catalogs.push({ name: catalogName, packages: { [pkgName]: version } })
+    }
+  },
+}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Closes #341

### 🧭 Context

<!-- Brief background and why this change is needed -->
Yarn supports pnpm catalogs. However, ni currently excludes them. Therefore, I have added support for it.

<!-- High-level summary of what changed -->
`src/catalog/detect.ts` - Added a Yarn Berry condition that returns the Yarn catalog provider
`src/catalog/yarn.ts` - A new file containing the Yarn catalog provider itself. 

### 📚 Description

I made a copy of the pnpm provider and made a few changes for Yarn.

I first changed the `findPnpmWorkspaceYaml` function to be `findYarnRcYaml`. After that, I modified the path to be `.yarnrc.yml` instead of `pnpm-workspace.yaml`. The rest is the same.

Initially, I attempted to use Yarn packages, but found that approach was getting messy. Then I decided to just stick with `pnpm-workspace-yaml` and allow that to do everything, as it does in the pnpm provider. After all, `catalog` and `catalogs` are the same in both.

After the implementation was finished, I built the project and packaged it (`pnpm pack`) so I could test it.

During this test, I replicated the examples in the project README, which can be seen below.

> [!NOTE]
> The commands that I run below make use of an `n` alias, which maps to `yarn ni`, to execute the local version instead of my global one.

Starting point for both `package.json` and `.yarnrc.yml`

<img width="871" height="349" alt="image" src="https://github.com/user-attachments/assets/9ebea367-ed97-4e1a-97a0-24a288b96bd3" />

Installing react with `ni react`. The prod catalog is detected, and react is written using `catalog:prod`.

<img width="840" height="653" alt="image" src="https://github.com/user-attachments/assets/d0c318e9-1065-492f-af3f-7e1004bb1616" />

Installing lodash with `ni lodash`. Since it's not in any catalog, ni shows the prompt.

<img width="587" height="139" alt="image" src="https://github.com/user-attachments/assets/488af53f-10c6-49c9-b7fd-c86f1808fdca" />

Following the prompt (`create new catalog` -> `default`), lodash is installed to the default catalog and has the `catalog:` value.

<img width="867" height="622" alt="image" src="https://github.com/user-attachments/assets/2b9b8919-a771-4899-a491-def5f432916a" />

Installing typescript with `ni typescript -D`. The prompt shows and a dev catalog is created. However, as per the `-D` flag, typescript is saved as a dev dependency rather than a regular dependency.

<img width="1148" height="634" alt="image" src="https://github.com/user-attachments/assets/4c13d059-eba1-45c9-94ff-e9cf1744d58f" />

And finally, installing react to the workspace root with `ni react -w`. As you can see, I ran the command in the UI package and instead of installing it to the ui package.json, it wrote it to the root.

<img width="757" height="738" alt="image" src="https://github.com/user-attachments/assets/036b3744-bbb7-407c-b98c-2c9f97a7df50" />


With that said, I also decided to try both flags (`-w` and `-d`).

`ni @commitlint/cli -w -d` shows the prompt, and a commitlint catalog is created.
`ni @commitlint/config-conventional -w -d` shows the prompt and the existing commitlint catalog is selected.

Both commands successfully save them as dev dependencies in the workspace root.

<img width="910" height="956" alt="image" src="https://github.com/user-attachments/assets/c3c1b756-0ca0-491a-8177-39e775ceb556" />
<img width="693" height="298" alt="image" src="https://github.com/user-attachments/assets/f4df478e-f360-405e-aabf-a7fb4fafca7d" />


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
