### PR TITLE
chore(deps): update package-manager-detector to 1.7.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,8 +50,8 @@ catalogs:
       specifier: ^0.5.2
       version: 0.5.2
     package-manager-detector:
-      specifier: ^1.6.0
-      version: 1.6.0
+      specifier: ^1.7.0
+      version: 1.7.0
     tinyexec:
       specifier: ^1.2.4
       version: 1.2.4
@@ -84,7 +84,7 @@ importers:
         version: 0.5.2
       package-manager-detector:
         specifier: catalog:prod
-        version: 1.6.0
+        version: 1.7.0
       tinyexec:
         specifier: catalog:prod
         version: 1.2.4
@@ -2133,8 +2133,8 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
-  package-manager-detector@1.6.0:
-    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+  package-manager-detector@1.7.0:
+    resolution: {integrity: sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==}
 
   parse-gitignore@2.0.0:
     resolution: {integrity: sha512-RmVuCHWsfu0QPNW+mraxh/xjQVw/lhUCUru8Zni3Ctq3AoMhpDTq0OVdKS6iesd6Kqb7viCV3isAL43dciOSog==}
@@ -2676,13 +2676,13 @@ snapshots:
 
   '@antfu/install-pkg@1.1.0':
     dependencies:
-      package-manager-detector: 1.6.0
+      package-manager-detector: 1.7.0
       tinyexec: 1.2.4
 
   '@antfu/ni@30.1.0':
     dependencies:
       fzf: 0.5.2
-      package-manager-detector: 1.6.0
+      package-manager-detector: 1.7.0
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
 
@@ -3585,7 +3585,7 @@ snapshots:
       args-tokenizer: 0.3.0
       cac: 7.0.0
       jsonc-parser: 3.3.1
-      package-manager-detector: 1.6.0
+      package-manager-detector: 1.7.0
       semver: 7.8.5
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
@@ -4616,7 +4616,7 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
-  package-manager-detector@1.6.0: {}
+  package-manager-detector@1.7.0: {}
 
   parse-gitignore@2.0.0: {}
 
@@ -4863,7 +4863,7 @@ snapshots:
       '@henrygd/queue': 1.2.0
       cac: 7.0.0
       ofetch: 1.5.1
-      package-manager-detector: 1.6.0
+      package-manager-detector: 1.7.0
       pathe: 2.0.3
       pnpm-workspace-yaml: 1.6.1
       restore-cursor: 5.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,7 +24,7 @@ catalogs:
     vitest: ^4.1.9
   prod:
     fzf: ^0.5.2
-    package-manager-detector: ^1.6.0
+    package-manager-detector: ^1.7.0
     tinyexec: ^1.2.4
     tinyglobby: ^0.2.17
   prod-inlined:

--- a/test/nlx/deno.spec.ts
+++ b/test/nlx/deno.spec.ts
@@ -12,7 +12,7 @@ function _(arg: string, expected: string) {
   }
 }
 
-it('single uninstall', _('esbuild', 'deno run npm:esbuild'))
-it('multiple', _('esbuild --version', 'deno run npm:esbuild --version'))
-it('vitest', _('vitest', 'deno run npm:vitest'))
-it('with args', _('typescript --version', 'deno run npm:typescript --version'))
+it('single uninstall', _('esbuild', 'deno x esbuild'))
+it('multiple', _('esbuild --version', 'deno x esbuild --version'))
+it('vitest', _('vitest', 'deno x vitest'))
+it('with args', _('typescript --version', 'deno x typescript --version'))

--- a/test/nr/npm.spec.ts
+++ b/test/nr/npm.spec.ts
@@ -23,14 +23,14 @@ it('script with arguments', _('build --watch -o', 'npm run build -- --watch -o')
 it('colon', _('build:dev', 'npm run build:dev'))
 
 // https://github.com/antfu-collective/ni/issues/322
-it('workspace flag before script', _('-w packages/foo test', 'npm run -w=packages/foo -- test'))
+it('workspace flag before script', _('-w packages/foo test', 'npm run -w=packages/foo test'))
 
-it('workspace long flag before script', _('--workspace packages/foo test', 'npm run --workspace=packages/foo -- test'))
+it('workspace long flag before script', _('--workspace packages/foo test', 'npm run --workspace=packages/foo test'))
 
 it('workspace flag after script', _('test -w packages/foo', 'npm run test -- -w=packages/foo'))
 
 it('workspace long flag after script', _('test --workspace packages/foo', 'npm run test -- --workspace=packages/foo'))
 
-it('workspace flag already joined with equals', _('-w=packages/foo test', 'npm run -w=packages/foo -- test'))
+it('workspace flag already joined with equals', _('-w=packages/foo test', 'npm run -w=packages/foo test'))
 
 it('trailing workspace flag without value', _('test -w', 'npm run test -- -w'))

--- a/test/programmatic/__snapshots__/runCli.spec.ts.snap
+++ b/test/programmatic/__snapshots__/runCli.spec.ts.snap
@@ -40,7 +40,7 @@ exports[`lockfile > deno > ni foo -D 1`] = `"deno add foo -D"`;
 
 exports[`lockfile > deno > ni foo 1`] = `"deno add foo"`;
 
-exports[`lockfile > deno > nlx 1`] = `"deno run npm:foo"`;
+exports[`lockfile > deno > nlx 1`] = `"deno x foo"`;
 
 exports[`lockfile > deno > nun -g foo 1`] = `"npm uninstall -g foo"`;
 
@@ -232,7 +232,7 @@ exports[`packager > deno > ni foo -D 1`] = `"deno add foo -D"`;
 
 exports[`packager > deno > ni foo 1`] = `"deno add foo"`;
 
-exports[`packager > deno > nlx 1`] = `"deno run npm:foo"`;
+exports[`packager > deno > nlx 1`] = `"deno x foo"`;
 
 exports[`packager > deno > nun -g foo 1`] = `"npm uninstall -g foo"`;
 

--- a/test/programmatic/detect.spec.ts
+++ b/test/programmatic/detect.spec.ts
@@ -30,7 +30,7 @@ afterAll(() => {
 
 const agents = [...AGENTS, 'unknown']
 const fixtures = ['lockfile', 'packager']
-const skippedAgents: string[] = []
+const skippedAgents: string[] = ['aube', 'nub']
 
 // matrix testing of: fixtures x agents
 fixtures.forEach(fixture => describe(fixture, () => agents.forEach((agent) => {

--- a/test/programmatic/runCli.spec.ts
+++ b/test/programmatic/runCli.spec.ts
@@ -60,7 +60,7 @@ afterAll(() => {
 
 const agents = [...AGENTS, 'unknown']
 const fixtures = ['lockfile', 'packager']
-const skippedAgents: string[] = []
+const skippedAgents: string[] = ['aube', 'nub']
 
 // matrix testing of: fixtures x agents x commands
 fixtures.forEach(fixture => describe(fixture, () => agents.forEach(agent => describe(agent, () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

Preparation for https://github.com/antfu-collective/ni/issues/335.

### 🧭 Context

<!-- Brief background and why this change is needed -->

`package-manager-detector` v1.7.0[^1] includes command resolution changes that affect existing ni expectations. Aligning the existing tests first keeps the follow-up aube and nub support easier to review.

[^1]: https://github.com/antfu-collective/package-manager-detector/releases/tag/v1.7.0

<!-- High-level summary of what changed -->

This updates ni to use `package-manager-detector` v1.7.0 and aligns existing tests with the new detector behavior. This PR intentionally does not add ni-level support for newly exposed package managers.

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

The dependency and lockfile are updated, the affected Deno and npm expectations are adjusted, and `aube` and `nub` are left out of the generic matrix until ni supports them directly.

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to npmx!
----------------------------------------------------------------------->
