### PR TITLE
feat: add support for aube

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm i -g <b>@antfu/ni</b>
 </code>
 </pre>
 
-<a href='https://docs.npmjs.com/cli/v6/commands/npm'>npm</a> · <a href='https://yarnpkg.com'>yarn</a> · <a href='https://pnpm.io/'>pnpm</a> · <a href='https://bun.sh/'>bun</a> · <a href='https://deno.land/'>deno</a>
+<a href='https://docs.npmjs.com/cli/v6/commands/npm'>npm</a> · <a href='https://yarnpkg.com'>yarn</a> · <a href='https://pnpm.io/'>pnpm</a> · <a href='https://bun.sh/'>bun</a> · <a href='https://deno.land/'>deno</a> · <a href='https://aube.jdx.dev/'>aube</a>
 
 <br>
 
@@ -26,6 +26,7 @@ ni
 # pnpm install
 # bun install
 # deno install
+# aube install
 ```
 
 ```bash
@@ -36,6 +37,7 @@ ni vite
 # pnpm add vite
 # bun add vite
 # deno add vite
+# aube add vite
 ```
 
 ```bash
@@ -46,6 +48,7 @@ ni @types/node -D
 # pnpm add -D @types/node
 # bun add -d @types/node
 # deno add -D @types/node
+# aube add -D @types/node
 ```
 
 ```bash
@@ -56,6 +59,7 @@ ni -P
 # pnpm i --production
 # bun install --production
 # (deno not supported)
+# aube install --production
 ```
 
 ```bash
@@ -67,6 +71,7 @@ ni --frozen
 # pnpm install --frozen-lockfile
 # bun install --frozen-lockfile
 # deno install --frozen
+# aube install --frozen-lockfile
 ```
 
 ```bash
@@ -77,6 +82,7 @@ ni -g eslint
 # pnpm add -g eslint
 # bun add -g eslint
 # deno install eslint
+# aube add -g eslint
 
 # this uses default agent, regardless your current working directory
 ```
@@ -146,6 +152,7 @@ nr dev --port=3000
 # pnpm run dev --port=3000
 # bun run dev --port=3000
 # deno task dev --port=3000
+# aube run dev --port=3000
 ```
 
 ```bash
@@ -201,6 +208,7 @@ nlx vitest
 # pnpm dlx vitest
 # bunx vitest
 # deno run npm:vitest
+# aube dlx vitest
 ```
 
 <br>
@@ -216,6 +224,7 @@ nup
 # pnpm update
 # bun update
 # deno upgrade
+# aube update
 ```
 
 ```bash
@@ -227,6 +236,7 @@ nup -i
 # pnpm update -i
 # bun update -i
 # deno outdated -u -i
+# aube update -i
 ```
 
 <br>
@@ -241,6 +251,7 @@ nun webpack
 # pnpm remove webpack
 # bun remove webpack
 # deno remove webpack
+# aube remove webpack
 ```
 
 ```bash
@@ -258,6 +269,7 @@ nun -g silent
 # pnpm remove -g silent
 # bun remove -g silent
 # deno uninstall -g silent
+# aube remove -g silent
 ```
 
 <br>
@@ -272,6 +284,7 @@ nci
 # pnpm install --frozen-lockfile
 # bun install --frozen-lockfile
 # deno cache --reload
+# aube install --frozen-lockfile
 ```
 
 <br>
@@ -284,6 +297,7 @@ nd
 # npm dedupe
 # yarn dedupe
 # pnpm dedupe
+# aube dedupe
 ```
 
 <br>
@@ -298,6 +312,7 @@ na
 # pnpm
 # bun
 # deno
+# aube
 ```
 
 ```bash
@@ -308,6 +323,7 @@ na run foo
 # pnpm run foo
 # bun run foo
 # deno task foo
+# aube run foo
 ```
 
 <br>
@@ -378,7 +394,7 @@ $Env:NI_CONFIG_FILE = 'C:\to\your\config\location'
 
 You can set `NI_AUTO_INSTALL=true` to enable automatic installation.
 
-If the corresponding package manager (**npm**, **yarn**, **pnpm**, **bun**, or **deno**) is not installed, it will install it globally before running the command.
+If the corresponding package manager (**npm**, **yarn**, **pnpm**, **bun**, **deno**, or **aube**) is not installed, it will install it globally before running the command.
 
 ### Integrations
 
@@ -409,7 +425,7 @@ asdf global ni latest
 
 **ni** assumes that you work with lock-files (and you should).
 
-Before `ni` runs the command, it detects your `yarn.lock` / `pnpm-lock.yaml` / `package-lock.json` / `bun.lock` / `bun.lockb` / `deno.json` / `deno.jsonc` to know the current package manager (or `packageManager` field in your packages.json if specified) using the [package-manager-detector](https://github.com/antfu-collective/package-manager-detector) package and then runs the corresponding [package-manager-detector command](https://github.com/antfu-collective/package-manager-detector/blob/main/src/commands.ts).
+Before `ni` runs the command, it detects your `yarn.lock` / `pnpm-lock.yaml` / `pnpm-workspace.yaml` / `package-lock.json` / `bun.lock` / `bun.lockb` / `deno.json` / `deno.jsonc` / `aube-lock.yaml` / `aube-workspace.yaml` to know the current package manager (or `packageManager` field in your packages.json if specified) using the [package-manager-detector](https://github.com/antfu-collective/package-manager-detector) package and then runs the corresponding [package-manager-detector command](https://github.com/antfu-collective/package-manager-detector/blob/main/src/commands.ts).
 
 ### Trouble shooting
 

--- a/src/commands/ni.ts
+++ b/src/commands/ni.ts
@@ -70,7 +70,7 @@ runCli(async (agent, args, ctx) => {
      * yarn and bun do not support
      * the installation of peers programmatically
      */
-    const canInstallPeers = ['npm', 'pnpm'].includes(agent)
+    const canInstallPeers = ['npm', 'pnpm', 'aube'].includes(agent)
 
     const { mode } = await prompts({
       type: 'select',

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -1,3 +1,4 @@
+import type { AgentName } from 'package-manager-detector'
 import { existsSync } from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
@@ -6,6 +7,10 @@ import { detect as detectPM } from 'package-manager-detector'
 import { INSTALL_PAGE } from 'package-manager-detector/constants'
 import { x } from 'tinyexec'
 import { cmdExists, terminalLink } from './utils'
+
+const INSTALL_PACKAGES: Partial<Record<AgentName, string>> = {
+  aube: '@endevco/aube',
+}
 
 export interface DetectOptions {
   autoInstall?: boolean
@@ -61,9 +66,10 @@ export async function detect({ autoInstall, programmatic, cwd }: DetectOptions =
         process.exit(1)
     }
 
+    const installPackage = INSTALL_PACKAGES[name] ?? name
     await x(
       'npm',
-      ['i', '-g', `${name}${version ? `@${version}` : ''}`],
+      ['i', '-g', `${installPackage}${version ? `@${version}` : ''}`],
       {
         nodeOptions: {
           stdio: 'inherit',

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -118,7 +118,8 @@ export const parseNup = <Runner>((agent, args) => {
 export const parseNd = <Runner>((agent, args) => {
   // https://yarnpkg.com/cli/dedupe#options
   // https://pnpm.io/cli/dedupe#--check
-  if (agent === 'pnpm')
+  // https://aube.jdx.dev/cli/dedupe
+  if (agent === 'pnpm' || agent === 'aube')
     args = args.map(i => i === '-c' ? '--check' : i)
 
   // https://docs.npmjs.com/cli/v11/commands/npm-dedupe#dry-run

--- a/test/fixtures/packager/aube/package.json
+++ b/test/fixtures/packager/aube/package.json
@@ -1,0 +1,3 @@
+{
+  "packageManager": "aube@1"
+}

--- a/test/na/aube.spec.ts
+++ b/test/na/aube.spec.ts
@@ -1,0 +1,17 @@
+import { expect, it } from 'vitest'
+import { parseNa, serializeCommand } from '../../src/commands'
+
+const agent = 'aube'
+function _(arg: string, expected: string) {
+  return async () => {
+    expect(
+      serializeCommand(await parseNa(agent, arg.split(' ').filter(Boolean))),
+    ).toBe(
+      expected,
+    )
+  }
+}
+
+it('empty', _('', 'aube'))
+it('foo', _('foo', 'aube foo'))
+it('run test', _('run test', 'aube run test'))

--- a/test/nci/aube.spec.ts
+++ b/test/nci/aube.spec.ts
@@ -1,0 +1,15 @@
+import { expect, it } from 'vitest'
+import { parseNi, serializeCommand } from '../../src/commands'
+
+const agent = 'aube'
+
+function _(hasLock: boolean, expected: string) {
+  return async () => {
+    const command = await parseNi(agent, ['--frozen-if-present'], { hasLock })
+    expect(serializeCommand(command)).toBe(expected)
+  }
+}
+
+it('uses a frozen install when a lockfile exists', _(true, 'aube install --frozen-lockfile'))
+
+it('uses a regular install when no lockfile exists', _(false, 'aube install'))

--- a/test/nd/aube.spec.ts
+++ b/test/nd/aube.spec.ts
@@ -1,0 +1,17 @@
+import { expect, it } from 'vitest'
+import { parseNd, serializeCommand } from '../../src/commands'
+
+const agent = 'aube'
+function _(arg: string, expected: string) {
+  return async () => {
+    expect(
+      serializeCommand(await parseNd(agent, arg.split(' ').filter(Boolean))),
+    ).toBe(
+      expected,
+    )
+  }
+}
+
+it('empty', _('', 'aube dedupe'))
+
+it('check', _('-c', 'aube dedupe --check'))

--- a/test/ni/aube.spec.ts
+++ b/test/ni/aube.spec.ts
@@ -1,0 +1,33 @@
+import { expect, it } from 'vitest'
+import { parseNi, serializeCommand } from '../../src/commands'
+
+const agent = 'aube'
+function _(arg: string, expected: string) {
+  return async () => {
+    expect(
+      serializeCommand(await parseNi(agent, arg.split(' ').filter(Boolean))),
+    ).toBe(
+      expected,
+    )
+  }
+}
+
+it('empty', _('', 'aube install'))
+
+it('single add', _('axios', 'aube add axios'))
+
+it('multiple', _('eslint @types/node', 'aube add eslint @types/node'))
+
+it('-D', _('-D eslint @types/node', 'aube add -D eslint @types/node'))
+
+it('global', _('eslint -g', 'aube add -g eslint'))
+
+it('frozen', _('--frozen', 'aube install --frozen-lockfile'))
+
+it('forwards long install flags', _('--anything', 'aube install --anything'))
+
+it('forwards short install flags', _('-a', 'aube install -a'))
+
+it('production', _('-P', 'aube install --production'))
+
+it('frozen production', _('--frozen -P', 'aube install --frozen-lockfile --production'))

--- a/test/nlx/aube.spec.ts
+++ b/test/nlx/aube.spec.ts
@@ -1,0 +1,16 @@
+import { expect, it } from 'vitest'
+import { parseNlx, serializeCommand } from '../../src/commands'
+
+const agent = 'aube'
+function _(arg: string, expected: string) {
+  return async () => {
+    expect(
+      serializeCommand(await parseNlx(agent, arg.split(' ').filter(Boolean))),
+    ).toBe(
+      expected,
+    )
+  }
+}
+
+it('single', _('esbuild', 'aube dlx esbuild'))
+it('with arguments', _('esbuild --version', 'aube dlx esbuild --version'))

--- a/test/nr/aube.spec.ts
+++ b/test/nr/aube.spec.ts
@@ -1,0 +1,23 @@
+import { expect, it } from 'vitest'
+import { parseNr, serializeCommand } from '../../src/commands'
+
+const agent = 'aube'
+function _(arg: string, expected: string) {
+  return async () => {
+    expect(
+      serializeCommand(await parseNr(agent, arg.split(' ').filter(Boolean))),
+    ).toBe(
+      expected,
+    )
+  }
+}
+
+it('empty', _('', 'aube run start'))
+
+it('if-present', _('test --if-present', 'aube run --if-present test'))
+
+it('script', _('dev', 'aube run dev'))
+
+it('script with arguments', _('build --watch -o', 'aube run build --watch -o'))
+
+it('colon', _('build:dev', 'aube run build:dev'))

--- a/test/nun/aube.spec.ts
+++ b/test/nun/aube.spec.ts
@@ -1,0 +1,21 @@
+import { expect, it } from 'vitest'
+import { parseNun, serializeCommand } from '../../src/commands'
+
+const agent = 'aube'
+function _(arg: string, expected: string) {
+  return async () => {
+    expect(
+      serializeCommand(await parseNun(agent, arg.split(' ').filter(Boolean))),
+    ).toBe(
+      expected,
+    )
+  }
+}
+
+it('single', _('axios', 'aube remove axios'))
+
+it('multiple', _('eslint @types/node', 'aube remove eslint @types/node'))
+
+it('forwards flags', _('-D eslint @types/node', 'aube remove -D eslint @types/node'))
+
+it('global', _('eslint -g', 'aube remove -g eslint'))

--- a/test/nup/aube.spec.ts
+++ b/test/nup/aube.spec.ts
@@ -1,0 +1,19 @@
+import { expect, it } from 'vitest'
+import { parseNup, serializeCommand } from '../../src/commands'
+
+const agent = 'aube'
+function _(arg: string, expected: string) {
+  return async () => {
+    expect(
+      serializeCommand(await parseNup(agent, arg.split(' ').filter(Boolean))),
+    ).toBe(
+      expected,
+    )
+  }
+}
+
+it('empty', _('', 'aube update'))
+
+it('interactive', _('-i', 'aube update -i'))
+
+it('interactive latest', _('-i --latest', 'aube update -i --latest'))

--- a/test/programmatic/__snapshots__/detect.spec.ts.snap
+++ b/test/programmatic/__snapshots__/detect.spec.ts.snap
@@ -1,5 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`lockfile > aube 1`] = `"aube"`;
+
 exports[`lockfile > bun 1`] = `"bun"`;
 
 exports[`lockfile > deno 1`] = `"deno"`;
@@ -15,6 +17,8 @@ exports[`lockfile > unknown 1`] = `undefined`;
 exports[`lockfile > yarn 1`] = `"yarn"`;
 
 exports[`lockfile > yarn@berry 1`] = `"yarn"`;
+
+exports[`packager > aube 1`] = `"aube"`;
 
 exports[`packager > bun 1`] = `"bun"`;
 

--- a/test/programmatic/__snapshots__/runCli.spec.ts.snap
+++ b/test/programmatic/__snapshots__/runCli.spec.ts.snap
@@ -2,6 +2,30 @@
 
 exports[`debug mode > should return command results in plain text format 1`] = `"npm i @antfu/ni"`;
 
+exports[`lockfile > aube > na 1`] = `"aube"`;
+
+exports[`lockfile > aube > na run foo 1`] = `"aube run foo"`;
+
+exports[`lockfile > aube > ni --frozen 1`] = `"aube install --frozen-lockfile"`;
+
+exports[`lockfile > aube > ni -g foo 1`] = `"npm i -g foo"`;
+
+exports[`lockfile > aube > ni 1`] = `"aube install"`;
+
+exports[`lockfile > aube > ni foo -D 1`] = `"aube add foo -D"`;
+
+exports[`lockfile > aube > ni foo 1`] = `"aube add foo"`;
+
+exports[`lockfile > aube > nlx 1`] = `"aube dlx foo"`;
+
+exports[`lockfile > aube > nun -g foo 1`] = `"npm uninstall -g foo"`;
+
+exports[`lockfile > aube > nun foo 1`] = `"aube remove foo"`;
+
+exports[`lockfile > aube > nup -i 1`] = `"aube update -i"`;
+
+exports[`lockfile > aube > nup 1`] = `"aube update"`;
+
 exports[`lockfile > bun > na 1`] = `"bun"`;
 
 exports[`lockfile > bun > na run foo 1`] = `"bun run foo"`;
@@ -193,6 +217,30 @@ exports[`lockfile > yarn@berry > nun foo 1`] = `"yarn remove foo"`;
 exports[`lockfile > yarn@berry > nup -i 1`] = `"yarn upgrade-interactive"`;
 
 exports[`lockfile > yarn@berry > nup 1`] = `"yarn upgrade"`;
+
+exports[`packager > aube > na 1`] = `"aube"`;
+
+exports[`packager > aube > na run foo 1`] = `"aube run foo"`;
+
+exports[`packager > aube > ni --frozen 1`] = `"aube install --frozen-lockfile"`;
+
+exports[`packager > aube > ni -g foo 1`] = `"npm i -g foo"`;
+
+exports[`packager > aube > ni 1`] = `"aube install"`;
+
+exports[`packager > aube > ni foo -D 1`] = `"aube add foo -D"`;
+
+exports[`packager > aube > ni foo 1`] = `"aube add foo"`;
+
+exports[`packager > aube > nlx 1`] = `"aube dlx foo"`;
+
+exports[`packager > aube > nun -g foo 1`] = `"npm uninstall -g foo"`;
+
+exports[`packager > aube > nun foo 1`] = `"aube remove foo"`;
+
+exports[`packager > aube > nup -i 1`] = `"aube update -i"`;
+
+exports[`packager > aube > nup 1`] = `"aube update"`;
 
 exports[`packager > bun > na 1`] = `"bun"`;
 

--- a/test/programmatic/detect-auto-install.spec.ts
+++ b/test/programmatic/detect-auto-install.spec.ts
@@ -1,0 +1,30 @@
+import { x } from 'tinyexec'
+import { expect, it, vi } from 'vitest'
+import { detect } from '../../src/detect'
+
+vi.mock('package-manager-detector', () => ({
+  detect: vi.fn(async () => ({
+    name: 'aube',
+    agent: 'aube',
+    version: '1.2.3',
+  })),
+}))
+
+vi.mock('tinyexec', () => ({
+  x: vi.fn(async () => ({})),
+}))
+
+vi.mock('../../src/utils', () => ({
+  cmdExists: vi.fn(() => false),
+  terminalLink: vi.fn((text: string) => text),
+}))
+
+it('installs aube from its scoped npm package', async () => {
+  await expect(detect({ autoInstall: true, cwd: __dirname })).resolves.toBe('aube')
+
+  expect(x).toHaveBeenCalledWith(
+    'npm',
+    ['i', '-g', '@endevco/aube@1.2.3'],
+    expect.objectContaining({ throwOnError: true }),
+  )
+})

--- a/test/programmatic/detect.spec.ts
+++ b/test/programmatic/detect.spec.ts
@@ -30,7 +30,7 @@ afterAll(() => {
 
 const agents = [...AGENTS, 'unknown']
 const fixtures = ['lockfile', 'packager']
-const skippedAgents: string[] = ['aube', 'nub']
+const skippedAgents: string[] = ['nub']
 
 // matrix testing of: fixtures x agents
 fixtures.forEach(fixture => describe(fixture, () => agents.forEach((agent) => {

--- a/test/programmatic/runCli.spec.ts
+++ b/test/programmatic/runCli.spec.ts
@@ -60,7 +60,7 @@ afterAll(() => {
 
 const agents = [...AGENTS, 'unknown']
 const fixtures = ['lockfile', 'packager']
-const skippedAgents: string[] = ['aube', 'nub']
+const skippedAgents: string[] = ['nub']
 
 // matrix testing of: fixtures x agents x commands
 fixtures.forEach(fixture => describe(fixture, () => agents.forEach(agent => describe(agent, () => {


### PR DESCRIPTION

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

resolves #335

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

`package-manager-detector` already detects aube and provides its base command mappings[^1]. However, ni still lacked the aube-specific handling required for automatic installation, interactive peer installs, and `nd -c`, and aube remained excluded from its integration coverage.

[^1]: https://github.com/antfu-collective/package-manager-detector/pull/69

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

This PR maps automatic installation to the [`@endevco/aube`](https://www.npmjs.com/package/@endevco/aube) npm package, enables peer dependency selection, and translates `nd -c` to `aube dedupe --check`. It also adds aube fixtures and command coverage across ni's aliases and documents the corresponding commands and detection files.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to this project!
----------------------------------------------------------------------->
