### PR TITLE
chore: fix `trustPolicyIgnoreAfter` unit

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ minimumReleaseAgeExclude:
 shellEmulator: true
 
 trustPolicy: no-downgrade
-trustPolicyIgnoreAfter: 604800 # 7 days
+trustPolicyIgnoreAfter: 10080 # 1 week
 
 packages: []
 catalogs:


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

/

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

The `trustPolicyIgnoreAfter` unit is minutes, not seconds.

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thank you for contributing to this project!
----------------------------------------------------------------------->

Refs:

- https://pnpm.io/settings#trustpolicyignoreafter
- https://github.com/pnpm/pnpm/blob/c98aef7b1f9633fe62348fc3187f9d95aabca554/pnpm-workspace.yaml#L553
